### PR TITLE
fix: add --allowedTools to Claude workflows

### DIFF
--- a/.github/workflows/claude-agents.yml
+++ b/.github/workflows/claude-agents.yml
@@ -43,6 +43,8 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
+          claude_args: |
+            --allowedTools "Bash(gh *)" "Bash(git *)" "Bash(dotnet *)" "Bash(pnpm *)" "Bash(make *)" "Bash(chmod *)" "Bash(echo *)" "Read" "Write" "Edit" "Glob" "Grep"
           prompt: |
             Read and follow .claude/skills/agent-pipeline/SKILL.md for pipeline protocols.
             Read and follow ${{ steps.agent.outputs.file }} for your role.

--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -40,6 +40,8 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
+          claude_args: |
+            --allowedTools "Bash(gh *)" "Bash(echo *)" "Bash(cat *)" "Read" "Write" "Edit" "Glob" "Grep"
           prompt: |
             Read and follow .claude/skills/agent-pipeline/SKILL.md for pipeline protocols.
             Read and follow .claude/agents/product-manager.md for your role.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,3 +35,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(gh *)" "Bash(git *)" "Bash(dotnet *)" "Bash(pnpm *)" "Bash(make *)" "Bash(echo *)" "Read" "Write" "Edit" "Glob" "Grep"


### PR DESCRIPTION
## Summary
- PM agent run had every Bash command denied (no human to approve in GH Actions)
- Added `--allowedTools` via `claude_args` to all three Claude workflows
- PM gets: `gh`, `echo`, `cat` + file tools
- Agents get: `gh`, `git`, `dotnet`, `pnpm`, `make`, `chmod`, `echo` + file tools
- Standard @claude gets: `gh`, `git`, `dotnet`, `pnpm`, `make`, `echo` + file tools

## Test plan
- [ ] Merge and add `agentic` label to a test issue
- [ ] Verify PM workflow runs and `gh` commands execute successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)