### PR TITLE
fix: gate PM workflow on agentic label for all events

### DIFF
--- a/.claude/skills/agent-pipeline/SKILL.md
+++ b/.claude/skills/agent-pipeline/SKILL.md
@@ -236,7 +236,7 @@ Follow your agent-specific implementation workflow (defined in your agent file).
 
 ```bash
 git push -u origin issue/{number}-{short-description}
-gh pr create --draft --title "{short title}" --body "Closes #{number}
+gh pr create --draft --label "agentic" --title "{short title}" --body "Closes #{number}
 
 {summary of changes}"
 ```

--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -9,17 +9,15 @@ on:
     types: [created]
   pull_request:
     types: [opened, closed, synchronize]
-  check_suite:
-    types: [completed]
 
 jobs:
   pm:
-    # Issues/comments: require 'agentic' label, skip agent/* labels and bot comments
-    # Everything else (schedule, check_suite, pull_request): always run
+    # All event types require the 'agentic' label except schedule (cron always runs)
     if: |
-      (github.event_name != 'issues' && github.event_name != 'issue_comment') ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'issue_comment' && !endsWith(github.event.comment.user.login, '[bot]') && contains(github.event.issue.labels.*.name, 'agentic')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agentic') && !(github.event.action == 'labeled' && startsWith(github.event.label.name, 'agent/')))
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agentic') && !(github.event.action == 'labeled' && startsWith(github.event.label.name, 'agent/'))) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'agentic'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- PR events now check `pull_request.labels` for the `agentic` label
- Implementation agents add `--label "agentic"` when creating draft PRs
- Removed `check_suite` trigger (payload doesn't include PR labels)
- Simplified `if` condition to explicit per-event checks with `agentic` gate

## Test plan
- [ ] Merge and verify non-agentic PRs don't trigger the PM workflow
- [ ] Verify agentic-labeled PRs still trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)