### PR TITLE
fix: add concurrency group to PM workflow

### DIFF
--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   pm:
+    # Only one PM run per issue at a time — newest wins, older runs are cancelled.
+    # Agents post multiple comments + remove labels within seconds, each generating
+    # a separate event. Without this, the PM fires 2-3 times per handback.
+    concurrency:
+      group: pm-${{ github.event.issue.number || github.event.pull_request.number || 'cron' }}
+      cancel-in-progress: true
     # All event types require the 'agentic' label except schedule (cron always runs)
     if: |
       github.event_name == 'schedule' ||


### PR DESCRIPTION
## Summary
- Adds a concurrency group to the PM workflow scoped per issue/PR number
- `cancel-in-progress: true` so only the latest PM run per issue survives

## Problem
Agents post multiple comments and remove labels within seconds. Each action generates a separate GitHub event, causing the PM to fire 2-3 times per handback. For example, an architect handback triggers:
1. `issue_comment` from the technical plan comment
2. `issue_comment` from the handback comment
3. `issues: unlabeled` from removing the `agent/architect` label

The PM also re-triggers on its own status comment.

## Test plan
- [ ] Add `agentic` label to an issue, verify PM runs once (not twice from its own status comment)
- [ ] Have an agent hand back, verify PM runs once (not 3 times from comment + comment + label removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)