### PR TITLE
fix: add concurrency group to agent dispatch workflow

### DIFF
--- a/.github/workflows/claude-agents.yml
+++ b/.github/workflows/claude-agents.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   dispatch:
+    # Only one agent run per issue at a time — prevents duplicate dispatches
+    concurrency:
+      group: agent-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     # Run when an agent/* label is added to an issue or PR that has the 'agentic' label
     if: |
       startsWith(github.event.label.name, 'agent/') && (


### PR DESCRIPTION
## Summary
- Adds a concurrency group to the agent dispatch workflow, same pattern as PM (#114)
- One agent run per issue at a time, newest cancels older

## Test plan
- [ ] Add an `agent/*` label, verify only one dispatch run executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)