### PR TITLE
feat: use GitHub App token for PM and agent dispatch workflows

### DIFF
--- a/.github/workflows/claude-agents.yml
+++ b/.github/workflows/claude-agents.yml
@@ -31,6 +31,13 @@ jobs:
         with:
           fetch-depth: 0  # Full history for implementation agents that need to create branches
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Determine agent and context
         id: agent
         run: |
@@ -60,7 +67,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -37,11 +37,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run PM Agent
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           additional_permissions: |
             actions: read
           claude_args: |


### PR DESCRIPTION
## Summary
- PM and agent dispatch workflows now use a GitHub App installation token instead of PAT
- Comments from agents will appear as `shadowbrook-agents[bot]` with a bot badge
- The `!endsWith(user.login, '[bot]')` check in the PM workflow now actually works
- `claude.yml` (standard @claude) is unchanged — still uses PAT

## Changes
- Added `actions/create-github-app-token@v1` step to both `claude-pm.yml` and `claude-agents.yml`
- Replaced `${{ secrets.PAT_TOKEN }}` with `${{ steps.app-token.outputs.token }}` for `github_token`
- Requires `APP_ID` and `APP_PRIVATE_KEY` repo secrets

## Test plan
- [ ] Add `agentic` label to an issue, verify PM comments appear as `shadowbrook-agents[bot]`
- [ ] Verify PM can still manage project fields (Projects v2 compatibility)
- [ ] Verify agent dispatch works with app token

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)