### PR TITLE
feat: add product owner review gates to agent pipeline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,7 +69,7 @@ Repo: `benjamingolfco/shadowbrook` | Project: #1 under `benjamingolfco` org
 Notes:
 - Use `-F` (not `-f`) for integer fields (e.g., `sub_issue_id`)
 - Issue types: Task, Bug, Feature, User Story
-- Project fields: Status (Triage/Needs Story/Needs Architecture/Ready/Implementing/CI Pending/In Review/Changes Requested/Ready to Merge/Awaiting Owner/Done), Priority (P0/P1/P2), Size (XS-XL)
+- Project fields: Status (Triage/Needs Story/Story Review/Needs Architecture/Architecture Review/Ready/Implementing/CI Pending/In Review/Changes Requested/Ready to Merge/Awaiting Owner/Done), Priority (P0/P1/P2), Size (XS-XL)
 
 ### Issue Labels
 
@@ -96,4 +96,4 @@ This project uses an automated multi-agent pipeline via GitHub Actions. See `.cl
 
 - **Workflow files:** `.github/workflows/claude-pm.yml` (orchestrator), `.github/workflows/claude-agents.yml` (dispatch)
 - **Agent definitions:** `.claude/agents/*.md`
-- **Pipeline statuses:** Triage → Needs Story → Needs Architecture → Ready → Implementing → CI Pending → In Review → Changes Requested → Ready to Merge → Done
+- **Pipeline statuses:** Triage → Needs Story → **Story Review** (owner gate) → Needs Architecture → **Architecture Review** (owner gate) → Ready → Implementing → CI Pending → In Review → Changes Requested → **Ready to Merge** (owner gate) → Done


### PR DESCRIPTION
## Summary

Adds three product owner review checkpoints to the pipeline. The pipeline pauses and tags `@aarongbenjamin` at each gate. The owner comments to approve or request changes.

### New pipeline flow

```
Triage → Needs Story → (BA) → Story Review → (Owner) → Needs Architecture → (Architect) → Architecture Review → (Owner) → Ready → (Dev) → CI Pending → In Review → (Reviewer) → Ready to Merge → (Owner approves PR) → Done
```

### Gate 1: Story Review
After BA refines the story, PM pauses and tags owner. Owner reviews acceptance criteria, comments to approve or request changes.

### Gate 2: Architecture Review  
After Architect posts technical plan, PM pauses and tags owner. Owner reviews the plan, comments to approve or request changes.

### Gate 3: PR Approval (existing)
After CI passes and code reviewer approves, PM publishes the PR and tags owner. Owner approves the PR on GitHub.

### Changes
- Added `Story Review` and `Architecture Review` project statuses (with new option IDs)
- Updated `agent-pipeline/SKILL.md` with review gate protocol and owner approval detection
- Updated `product-manager.md` routing logic, status IDs, triage flow, and cron reminders
- Updated `CLAUDE.md` pipeline status list

## Test plan
- [ ] BA hands back → PM sets Story Review, tags owner (not architect)
- [ ] Owner comments approval → PM advances to Needs Architecture
- [ ] Owner comments feedback → PM sends back to BA
- [ ] Architect hands back → PM sets Architecture Review, tags owner (not dev)
- [ ] Owner comments approval → PM advances to Ready
- [ ] 48h with no owner response → PM posts reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)