### PR TITLE
fix: add GitHub App bot to allowed_bots

### DIFF
--- a/.github/workflows/claude-agents.yml
+++ b/.github/workflows/claude-agents.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: "benjamingolfco-claude-agent[bot]"
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: "benjamingolfco-claude-agent[bot]"
           additional_permissions: |
             actions: read
           claude_args: |


### PR DESCRIPTION
## Summary
- Adds `benjamingolfco-claude-agent[bot]` to `allowed_bots` in both PM and agent dispatch workflows
- `claude-code-action` blocks bot-initiated events by default — this allows our app's actions (label changes, comments) to trigger workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)