### PR TITLE
feat: trigger PM on CI completion

### DIFF
--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -9,6 +9,8 @@ on:
     types: [created]
   pull_request:
     types: [opened, closed, synchronize]
+  check_suite:
+    types: [completed]
 
 jobs:
   pm:
@@ -16,14 +18,15 @@ jobs:
     # Agents post multiple comments + remove labels within seconds, each generating
     # a separate event. Without this, the PM fires 2-3 times per handback.
     concurrency:
-      group: pm-${{ github.event.issue.number || github.event.pull_request.number || 'cron' }}
+      group: pm-${{ github.event.issue.number || github.event.pull_request.number || github.event.check_suite.id || 'cron' }}
       cancel-in-progress: true
     # All event types require the 'agentic' label except schedule (cron always runs)
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'issue_comment' && !endsWith(github.event.comment.user.login, '[bot]') && contains(github.event.issue.labels.*.name, 'agentic')) ||
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agentic') && !(github.event.action == 'labeled' && startsWith(github.event.label.name, 'agent/'))) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'agentic'))
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
+      (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0])
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -63,4 +66,5 @@ jobs:
 
             Analyze the current state and take appropriate action based on your role definition.
             If this is a scheduled run, perform your cron duties (scan for stalled work, check backlog, update status comments).
+            If this is a check_suite event, CI has completed. Check the result and associated PR, then act according to the CI Gate section of your role definition.
             If this is an event, respond to the specific event appropriately.


### PR DESCRIPTION
## Summary
- Adds `check_suite: [completed]` trigger to the PM workflow
- When CI finishes on a PR, the PM fires and checks pass/fail
- PM routes to code reviewer if CI passes, or back to implementation agent if it fails
- Previously CI completion was only detected on the 12-hour cron scan

## Test plan
- [ ] Agent opens draft PR → CI runs → CI completes → PM fires and detects the result
- [ ] CI passes → PM sets In Review, assigns code reviewer
- [ ] CI fails → PM routes back to implementation agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)