### PR TITLE
feat: trigger PM on pull request review submission

### DIFF
--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -9,6 +9,8 @@ on:
     types: [created]
   pull_request:
     types: [opened, closed, synchronize]
+  pull_request_review:
+    types: [submitted]
   check_suite:
     types: [completed]
 
@@ -18,7 +20,7 @@ jobs:
     # Agents post multiple comments + remove labels within seconds, each generating
     # a separate event. Without this, the PM fires 2-3 times per handback.
     concurrency:
-      group: pm-${{ github.event.issue.number || github.event.pull_request.number || github.event.check_suite.id || 'cron' }}
+      group: pm-${{ github.event.issue.number || github.event.pull_request.number || github.event.review.pull_request_url || github.event.check_suite.id || 'cron' }}
       cancel-in-progress: true
     # All event types require the 'agentic' label except schedule (cron always runs)
     if: |
@@ -26,6 +28,7 @@ jobs:
       (github.event_name == 'issue_comment' && !endsWith(github.event.comment.user.login, '[bot]') && contains(github.event.issue.labels.*.name, 'agentic')) ||
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agentic') && !(github.event.action == 'labeled' && startsWith(github.event.label.name, 'agent/'))) ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
       (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0])
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Adds `pull_request_review: [submitted]` trigger to PM workflow
- PM now fires when the code reviewer submits a review (approve or request changes)
- Gates on `agentic` label on the PR, same as other PR events

The `pull_request_review` event activity types are `submitted`, `edited`, `dismissed` — we only need `submitted`.

## Test plan
- [ ] Code reviewer approves PR → PM fires, detects approval, publishes PR
- [ ] Code reviewer requests changes → PM fires, routes back to implementation agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)