### PR TITLE
feat: trigger PM on PR line-level review comments

### DIFF
--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -11,6 +11,8 @@ on:
     types: [opened, closed, synchronize]
   pull_request_review:
     types: [submitted]
+  pull_request_review_comment:
+    types: [created]
   check_suite:
     types: [completed]
 
@@ -29,6 +31,7 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agentic') && !(github.event.action == 'labeled' && startsWith(github.event.label.name, 'agent/'))) ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
+      (github.event_name == 'pull_request_review_comment' && !endsWith(github.event.comment.user.login, '[bot]') && contains(github.event.pull_request.labels.*.name, 'agentic')) ||
       (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0])
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Adds `pull_request_review_comment: [created]` trigger to PM workflow
- PM now fires when someone leaves a line comment on a PR diff
- Skips bot comments (`!endsWith([bot])`) and gates on `agentic` label

### Full PM trigger coverage now:
| Event | What it catches |
|-------|----------------|
| `schedule` | Cron maintenance |
| `issues` | Label changes, new issues |
| `issue_comment` | Comments on issues AND regular PR conversation comments |
| `pull_request` | PR opened, closed, updated |
| `pull_request_review` | Review submitted (approve/request changes) |
| `pull_request_review_comment` | Line comments on PR diffs |
| `check_suite` | CI completion |

🤖 Generated with [Claude Code](https://claude.com/claude-code)