### PR TITLE
chore: increase PM cron frequency to every 6 hours

### DIFF
--- a/.github/workflows/claude-pm.yml
+++ b/.github/workflows/claude-pm.yml
@@ -2,7 +2,7 @@ name: Claude PM Agent
 
 on:
   schedule:
-    - cron: '0 6,18 * * *' # Midnight & noon CST (UTC-6)
+    - cron: '0 0,6,12,18 * * *' # Every 6 hours UTC (midnight, 6am, noon, 6pm CST offset)
   issues:
     types: [opened, labeled, unlabeled]
   issue_comment:


### PR DESCRIPTION
## Summary
- Bumps PM cron from every 12 hours to every 6 hours (00:00, 06:00, 12:00, 18:00 UTC)
- Faster detection of stalled agents, awaiting-owner reminders, and backlog processing

## Test plan
- [ ] Verify cron triggers at expected times in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)