### PR TITLE
feat: add ad-hoc @agent mentions in issues and PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,3 +97,4 @@ This project uses an automated multi-agent pipeline via GitHub Actions. See `.cl
 - **Workflow files:** `.github/workflows/claude-pm.yml` (orchestrator), `.github/workflows/claude-agents.yml` (dispatch)
 - **Agent definitions:** `.claude/agents/*.md`
 - **Pipeline statuses:** Triage → Needs Story → **Story Review** (owner gate) → Needs Architecture → **Architecture Review** (owner gate) → Ready → Implementing → CI Pending → In Review → Changes Requested → **Ready to Merge** (owner gate) → Done
+- **Ad-hoc agent mentions:** Comment `@agent:backend`, `@agent:architect`, etc. on any issue or PR to get direct help from a specialist agent outside the pipeline (no `agentic` label required)

--- a/.claude/skills/agent-pipeline/SKILL.md
+++ b/.claude/skills/agent-pipeline/SKILL.md
@@ -184,7 +184,8 @@ _Run: [#95](https://github.com/org/repo/actions/runs/12345)_
 ### @mention Rules
 
 - **Only the PM** @mentions the product owner (`@aarongbenjamin`). Specialist agents never @mention anyone — they hand back to the PM, which handles all notifications.
-- **Never @mention** agents — they are triggered by labels, not mentions.
+- **Never @mention agents in pipeline context** — pipeline routing uses labels, not mentions.
+- **Ad-hoc @mentions** — anyone can `@agent:backend`, `@agent:architect`, etc. in any issue or PR comment to get direct help from a specialist agent outside the pipeline. These ad-hoc invocations do not trigger pipeline handoff protocols (no handback comments, no label changes, no PM status updates).
 - The `> **Action Required:**` callout must appear on every comment where someone needs to act.
 
 ### Run Link Footer

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,3 +45,64 @@ jobs:
 
           claude_args: |
             --model claude-sonnet-4-5-20250929
+
+  agent:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@agent:')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@agent:')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@agent:')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@agent:'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Extract agent name from comment
+        id: agent
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
+        run: |
+          AGENT_NAME=$(echo "$COMMENT_BODY" | grep -oP '@agent:([a-z][-a-z]*)' | head -1 | sed 's/@agent://')
+          if [ -z "$AGENT_NAME" ]; then
+            echo "::error::Could not extract agent name from comment"
+            exit 1
+          fi
+          echo "name=$AGENT_NAME" >> $GITHUB_OUTPUT
+          echo "file=.claude/agents/${AGENT_NAME}.md" >> $GITHUB_OUTPUT
+
+      - name: Verify agent file exists
+        run: |
+          if [ ! -f "${{ steps.agent.outputs.file }}" ]; then
+            echo "::error::Unknown agent: ${{ steps.agent.outputs.name }}. Available agents: $(ls .claude/agents/*.md | xargs -I{} basename {} .md | tr '\n' ', ')"
+            exit 1
+          fi
+
+      - name: Run Agent
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: "benjamingolfco-claude-agent[bot]"
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-sonnet-4-5-20250929 --allowedTools "Bash" "Read" "Write" "Edit" "Glob" "Grep"
+          prompt: |
+            Read .claude/agents/${{ steps.agent.outputs.name }}.md for your role and expertise.
+            You were @mentioned directly in a comment. Respond helpfully to the user's request.
+            This is an ad-hoc request — do NOT follow pipeline handoff protocols (no handback comments, no label changes, no PM status updates).


### PR DESCRIPTION
## Summary
- Adds an `agent` job to `claude.yml` that triggers when anyone comments `@agent:backend`, `@agent:architect`, etc. on any issue or PR
- Agents respond directly to the comment in ad-hoc mode — no pipeline side effects (no label changes, no handback comments, no PM status updates)
- No `agentic` label required — works on any issue or PR
- Invalid agent names fail gracefully with a list of available agents

## Test plan
- [ ] Comment `@agent:architect` on any issue and verify the workflow triggers and the agent responds
- [ ] Comment `@agent:nonexistent` and verify the workflow fails gracefully in logs
- [ ] Comment `@claude` on an issue and verify the existing job still works independently
- [ ] Verify no pipeline side effects (no label changes, no PM status updates) from ad-hoc mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)