### PR TITLE
Add concurrency group to owner-gate workflow to prevent duplicate checks

### DIFF
--- a/.github/workflows/owner-gate.yml
+++ b/.github/workflows/owner-gate.yml
@@ -11,6 +11,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: owner-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   owner-gate:
     name: owner-approval


### PR DESCRIPTION
When both pull_request and pull_request_review events fire for the same PR,
the older run is now cancelled so only one check appears at a time.

https://claude.ai/code/session_0156oDrB4WRfUh1Qpyq4tWqt