### PR TITLE
chore: reduce pipeline noise and cost

### DIFF
--- a/.claude/agents/planning-manager.md
+++ b/.claude/agents/planning-manager.md
@@ -188,7 +188,7 @@ Do all maintenance and corrective work first so the standup reflects the current
 
 **Stalled work:** Query issues in Needs Story or Needs Architecture status. The project `items` GraphQL connection supports server-side filtering via the `query` argument (e.g., `query: "status:\"Needs Story\""`). If no agent comment within 24h, post a ping and re-spawn the agent.
 
-**Review gate reminders:** Query issues in Story Review or Architecture Review (e.g., `query: "status:\"Story Review\""`). If 48h+ with no owner comment, post an Action Required reminder to `@aarongbenjamin`.
+**Review gate reminders:** Query issues in Story Review or Architecture Review (e.g., `query: "status:\"Story Review\""`). If 48h+ with no owner comment, post an Action Required reminder to `@aarongbenjamin`. **Cooldown:** Do NOT re-remind an issue if a bot reminder comment already exists within the last 7 days — check the issue's recent comments before posting. Limit to 5 reminders per cron cycle to avoid comment spam.
 
 **Issue Plan refresh:** Update all Issue Plan comments on active issues to reflect current state.
 

--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -16,7 +16,7 @@ on:
   check_suite:
     types: [completed]
   schedule:
-    - cron: '0 0-3,6,12,15-23 * * *'  # Every hour 9am–9pm CST + midnight + 6am CST
+    - cron: '0 2,6,14,18,22 * * *'  # Every ~4 hours UTC (8pm, midnight, 8am, noon, 4pm CST)
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────

--- a/.github/workflows/claude-planning.yml
+++ b/.github/workflows/claude-planning.yml
@@ -3,10 +3,8 @@ name: Shadowbrook Planning
 on:
   issues:
     types: [opened, labeled, unlabeled]
-  issue_comment:
-    types: [created]
   schedule:
-    - cron: '0 0,6,12,18 * * *'  # Every 6 hours UTC
+    - cron: '0 0,8,16 * * *'  # Every 8 hours UTC (6pm, 2am, 10am CST)
 
 jobs:
   planning:
@@ -15,8 +13,7 @@ jobs:
       cancel-in-progress: true
     if: |
       (github.event_name == 'schedule') ||
-      (github.event_name == 'issues' && !contains(github.event.issue.labels.*.name, 'agent/ignore')) ||
-      (github.event_name == 'issue_comment' && !github.event.issue.pull_request && !endsWith(github.event.comment.user.login, '[bot]') && !contains(github.event.issue.labels.*.name, 'agent/ignore'))
+      (github.event_name == 'issues' && !contains(github.event.issue.labels.*.name, 'agent/ignore'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -37,13 +34,6 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Acknowledge comment
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -X POST -f content="eyes"
-
       - name: Run Planning Manager
         uses: anthropics/claude-code-action@v1
         with:
@@ -54,7 +44,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6 --allowedTools "Bash" "Read" "Write" "Edit" "Glob" "Grep" "Task"
+            --model ${{ github.event_name == 'schedule' && 'claude-sonnet-4-5-20250929' || 'claude-opus-4-6' }} --allowedTools "Bash" "Read" "Write" "Edit" "Glob" "Grep" "Task"
           prompt: |
             You are the Planning Manager for the Shadowbrook agent pipeline.
 


### PR DESCRIPTION
## Summary
- **Remove `issue_comment` trigger from planning workflow** — eliminates ~376 skipped runs/week from bot self-triggering. Owner approvals are picked up by the next cron cycle instead.
- **Reduce cron frequencies** — planning from 4x to 3x/day (every 8h), implementation from 15x to 5x/day (every ~4h)
- **Use Sonnet for planning cron** — routine housekeeping (reminders, stalled work checks, sprint overviews) doesn't need Opus. Saves ~$3.60/day.
- **Add reminder cooldown** — 7-day cooldown and 5/cycle cap prevents repetitive Story Review comment spam on the same issues

## Test plan
- [ ] Verify planning cron fires at expected times (0, 8, 16 UTC)
- [ ] Verify implementation cron fires at expected times (2, 6, 14, 18, 22 UTC)
- [ ] Verify new issue creation still triggers planning workflow (issues:opened)
- [ ] Verify planning cron uses Sonnet (check model in run logs)
- [ ] Verify issue-triggered planning uses Opus (check model in run logs)
- [ ] Verify reminder cooldown is respected (no re-reminders within 7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)