### PR TITLE
chore: disable agentic pipeline

### DIFF
--- a/.github/workflows/claude-implementation.yml
+++ b/.github/workflows/claude-implementation.yml
@@ -1,22 +1,23 @@
 name: Shadowbrook Implementation
 
 on:
-  workflow_dispatch:
-    inputs:
-      issue_number:
-        description: 'Issue number to dispatch for sprint execution (leave empty to run find-work)'
-        required: false
-        type: string
-  issue_comment:
-    types: [created]
-  pull_request:
-    types: [opened, closed, synchronize]
-  pull_request_review:
-    types: [submitted]
-  check_suite:
-    types: [completed]
-  schedule:
-    - cron: '0 2,6,14,18,22 * * *'  # Every ~4 hours UTC (8pm, midnight, 8am, noon, 4pm CST)
+  workflow_dispatch:  # manual-only while pipeline is disabled
+  # workflow_dispatch:
+  #   inputs:
+  #     issue_number:
+  #       description: 'Issue number to dispatch for sprint execution (leave empty to run find-work)'
+  #       required: false
+  #       type: string
+  # issue_comment:
+  #   types: [created]
+  # pull_request:
+  #   types: [opened, closed, synchronize]
+  # pull_request_review:
+  #   types: [submitted]
+  # check_suite:
+  #   types: [completed]
+  # schedule:
+  #   - cron: '0 2,6,14,18,22 * * *'  # Every ~4 hours UTC (8pm, midnight, 8am, noon, 4pm CST)
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────

--- a/.github/workflows/claude-planning.yml
+++ b/.github/workflows/claude-planning.yml
@@ -1,10 +1,11 @@
 name: Shadowbrook Planning
 
 on:
-  issues:
-    types: [opened, labeled, unlabeled]
-  schedule:
-    - cron: '0 0,8,16 * * *'  # Every 8 hours UTC (6pm, 2am, 10am CST)
+  workflow_dispatch:  # manual-only while pipeline is disabled
+  # issues:
+  #   types: [opened, labeled, unlabeled]
+  # schedule:
+  #   - cron: '0 0,8,16 * * *'  # Every 8 hours UTC (6pm, 2am, 10am CST)
 
 jobs:
   planning:


### PR DESCRIPTION
## Summary
- Disables automatic triggers on planning and implementation workflows (manual dispatch only)
- Code review workflow remains active
- Original triggers preserved as comments for easy re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)