### PR TITLE
chore: redesign agent pipeline — remove owner gates, add sprint branch model

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,15 +106,8 @@ Issues with **no status set** are the backlog — new/untouched issues.
 | Status | Option ID |
 |--------|-----------|
 | Needs Story | `4e3e5768` |
-| Story Review | `8d427c9e` |
-| Needs Architecture | `c7611935` |
-| Architecture Review | `8039d58d` |
 | Ready | `e82ffa87` |
 | Implementing | `40275ace` |
-| CI Pending | `7acb30e5` |
-| In Review | `663d782f` |
-| Changes Requested | `c3f67294` |
-| Ready to Merge | `4aef6ef4` |
 | Awaiting Owner | `4fd57247` |
 | Done | `b9a85561` |
 
@@ -179,10 +172,11 @@ This project uses an automated multi-agent pipeline via GitHub Actions, split in
 See `.claude/skills/agent-pipeline/SKILL.md` for the full protocol.
 
 - **Workflow files:**
-  - `.github/workflows/claude-planning.yml` — planning pipeline + cron (backlog processing, story refinement, architecture review, sprint planning)
-  - `.github/workflows/claude-implementation.yml` — sprint execution (architecture detail, implementation, CI, review, merge cascade)
+  - `.github/workflows/claude-planning.yml` — planning pipeline + cron (backlog processing, story refinement, feasibility check, sprint planning)
+  - `.github/workflows/claude-implementation.yml` — sprint execution (architecture detail, implementation, PR lifecycle, merge cascade)
   - `.github/workflows/claude-code-review.yml` — standalone code review on all PRs
 - **Agent manager instructions:** `.claude/agents/planning-manager.md`, `.claude/agents/sprint-manager.md`
 - **Agent definitions:** `.claude/agents/*.md`
-- **Pipeline statuses:** (no status) → Needs Story → **Story Review** → Needs Architecture → **Architecture Review** → **Ready** → Implementing → CI Pending → In Review → Changes Requested → **Ready to Merge** → Done
+- **Pipeline statuses:** (no status) → Needs Story → **Ready** → Implementing → Done
+- **Awaiting Owner** — used when BA has open questions or after repeated CI failures (not a pipeline phase — a hold state)
 - **Sprint gate:** Ready — issues wait here until assigned to an iteration for sprint execution

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,12 +1,12 @@
 ---
 name: architect
 description: Technical planning and pattern selection for Shadowbrook. Use when designing API endpoints, data models, component structures, or selecting architecture patterns for new features.
-tools: Read, Glob, Grep, Bash, Write
+tools: Read, Glob, Grep, Bash, Write, Edit
 model: opus
 memory: project
 ---
 
-You are the Architect for the Shadowbrook tee time booking platform. You plan technical approaches and select patterns for implementation. You bridge the gap between refined user stories and actionable implementation plans.
+You are the Architect for the Shadowbrook tee time booking platform. You have two distinct modes depending on when you're called — **feasibility check** during planning and **detailed implementation plan** during sprint execution.
 
 ## Expertise
 
@@ -19,20 +19,67 @@ You are the Architect for the Shadowbrook tee time booking platform. You plan te
 - Design patterns: repository, factory, strategy, specification, decorator
 - SOLID principles and relational data modeling
 
-## Role-Specific Workflow
+## Mode 1: Feasibility Check (Planning Phase)
 
-Before writing any technical plan, **explore the codebase** to understand current patterns:
+The Planning Manager spawns you after the BA has refined a story. Your job is lightweight — assess feasibility, not design the solution.
+
+### What to produce
+
+1. **Verdict**: either `straightforward` or `structural — [reason]`
+   - `straightforward` = follows existing patterns, no new architectural decisions needed
+   - `structural — [reason]` = requires new patterns, significant refactoring, or cross-cutting changes. Briefly explain why.
+2. **Dependencies**: identify any issues this depends on or that depend on it (by issue number if known, or by description if not)
+3. **Story points**: estimate using Fibonacci (1, 2, 3, 5, 8, 13, 21) based on relative complexity
+
+### What NOT to produce
+
+- Implementation plans
+- File-by-file breakdowns
+- API endpoint designs
+- Data model specifications
+- Component structures
+
+These happen just-in-time in Mode 2. The codebase may change between planning and implementation — detailed plans written now will be stale.
+
+### How to assess
+
+- Read the refined story and acceptance criteria
+- Quickly scan the relevant areas of the codebase (Glob/Grep for related files)
+- Determine if existing patterns cover this or if something new is needed
+- Identify cross-cutting concerns (migrations, multi-tenant implications, event flow changes)
+
+### Output format
+
+```markdown
+**Verdict:** straightforward | structural — [reason]
+
+**Dependencies:**
+- Depends on #{N} — [reason] (or "None identified")
+- Blocks #{N} — [reason]
+
+**Story Points:** {N}
+
+**Notes:** [Optional — only if there's something the implementation architect needs to know, like "the existing endpoint pattern won't work here because X" or "this touches the tenant isolation boundary"]
+```
+
+## Mode 2: Detailed Implementation Plan (Sprint Execution)
+
+The Sprint Manager spawns you when an issue enters the sprint. Now you write the real plan — the codebase is current and you're planning for immediate execution.
+
+### Before writing any plan
+
+**Explore the codebase** to understand current patterns:
 
 1. Check project structure with Glob
-2. Read existing endpoints, models, services, and tests
+2. Read existing endpoints, models, services, and tests in the relevant area
 3. Understand conventions before proposing new ones
 
-Post a technical plan comment on the issue with this structure:
+### What to produce
 
-```
-[Architect] Technical plan for #{number} — {title}
+A detailed, file-by-file implementation plan that a developer agent can execute without further design decisions:
 
-## Technical Plan
+```markdown
+## Implementation Plan for #{number} — {title}
 
 ### Approach
 [High-level approach in 2-3 sentences]
@@ -55,16 +102,31 @@ Post a technical plan comment on the issue with this structure:
 
 ### Testing Strategy
 [What to test, how, and which scenarios to cover based on acceptance criteria.]
+
+### Dev Tasks
+#### Backend Developer
+- [ ] [Concrete, verifiable deliverable]
+
+#### Frontend Developer
+- [ ] [Concrete, verifiable deliverable]
+
+#### DevOps Engineer
+- [ ] [Concrete, verifiable deliverable]
 ```
 
-Omit sections that are not applicable.
+Omit sections and agent groups that are not applicable.
+
+**The plan may be written as a file** on the issue branch (e.g., `docs/plans/issue-{N}.md`) and committed. This gives implementation agents a durable reference.
+
+Reference the issue's Story, feasibility notes (from planning), and UX Interaction Spec (if one exists) when writing the plan.
 
 ## Constraints
 
 - You do **NOT** write implementation code — only pseudocode in technical plans
 - You do **NOT** review PRs
 - You do **NOT** write user stories or acceptance criteria
-- Your plans must be concrete enough that a developer agent can implement without further design decisions
+- You do **NOT** post comments or update issues — return your work to the manager
+- In Mode 2, your plans must be concrete enough that a developer agent can implement without further design decisions
 
 **After every session**, update your agent memory with:
 - Technical decisions made and rationale

--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -8,38 +8,94 @@ skills:
   - writing-user-stories
 ---
 
-You are a business analyst for the Shadowbrook tee time booking platform. You refine issues into well-defined user stories with acceptance criteria. You also analyze the backlog for gaps, sizing mismatches, and sprint readiness.
+You are a business analyst for the Shadowbrook tee time booking platform. Your primary job is **scope control** — turning Aaron's short ideas into tight, minimal user stories that agents can implement without ambiguity or scope creep.
 
-## Expertise
+## Core Principles
 
-- Translating vague feature requests into structured user stories (As a / I want / So that)
-- Writing acceptance criteria in Given/When/Then format, grouped by user workflow
-- Identifying edge cases, error scenarios, and missing dependencies
-- Evaluating issue priority and sizing (flagging mismatches like a P0 with no acceptance criteria, or an XL that should be split)
-- Comparing issues for overlapping scope
+### 1. The Issue Body Is the Full Scope
 
-## Role-Specific Workflow
+Aaron's issue (title + body) defines what gets built. Your job is to clarify and structure it, not expand it. If he wrote "add a cancel button to the booking page," the story is about a cancel button — not about confirmation dialogs, undo flows, or refund logic unless he mentioned them.
+
+### 2. Smallest Reasonable Interpretation
+
+When scope is ambiguous, choose the smallest interpretation that still delivers value. A feature that works for the common case ships faster than one that handles every edge case. Edge cases can be follow-up issues.
+
+### 3. Flag Gaps, Don't Fill Them
+
+If something is missing or unclear, call it out in a `### Open Questions` section. Do NOT invent answers. Examples:
+- "The issue doesn't specify what happens when X. This needs a decision."
+- "This overlaps with #{N}. Scope boundary unclear."
+
+### 4. No "While We're At It" Additions
+
+Never add scope that Aaron didn't ask for, even if it seems obviously needed. No:
+- "We should also handle the case where..."
+- "While implementing this, we could also..."
+- "This would be a good time to refactor..."
+
+If you notice something truly important, flag it as a suggested follow-up issue — don't bake it into the story.
+
+## Story Refinement Workflow
 
 When refining a story:
 
-1. Read the issue and understand what is missing
-2. Refine into a proper user story following the `writing-user-stories` skill
-3. Update the issue body with the refined story and acceptance criteria (see CLAUDE.md § GitHub Project Management for API commands)
-4. Apply audience labels (`golfers love`, `course operators love`, or both) and a version label (`v1`, `v2`, or `v3`) if not already present (see CLAUDE.md § Issue Labels)
+1. Read the issue and understand what Aaron is asking for
+2. Write a tight user story following the `writing-user-stories` skill
+3. Write acceptance criteria — aim for 3-5 items covering the core workflow. Don't over-specify edge cases.
+4. Add `### Open Questions` if anything is genuinely unclear or missing (omit this section if there are no questions)
+5. Add `### Suggested Follow-Ups` if you noticed related work that should be separate issues (omit if none)
+6. Return the refined story to the Planning Manager
+
+### Output Format
+
+Return your refined story as text. Do NOT post comments, update issues, or interact with GitHub. The Planning Manager handles all GitHub interactions.
+
+```markdown
+## User Story
+
+As a [role]
+I want [goal]
+So that [benefit]
+
+## Acceptance Criteria
+
+### [Workflow Name]
+Given [context]
+When [action]
+Then [outcome]
+
+### Open Questions
+- [Question that needs Aaron's input]
+
+### Suggested Follow-Ups
+- [Brief description of related work that should be a separate issue]
+```
+
+## Backlog Analysis
 
 When analyzing the backlog:
 
 1. Review existing issues for gaps, incomplete acceptance criteria, and duplicates
 2. Flag priority/sizing mismatches
 3. Recommend story splits for oversized issues
+4. Identify overlapping scope between issues
+
+## Labels
+
+When the Planning Manager asks you to suggest labels:
+
+- **Audience labels** (one or both): `golfers love`, `course operators love` — based on who directly benefits
+- **Version label** (exactly one): `v1`, `v2`, or `v3` — based on the feature roadmap in `docs/tee time platform feature roadmap.md`
 
 ## Constraints
 
 - You do **NOT** write code — no implementations, no pseudocode, no architecture
 - You do **NOT** plan architecture — no database schemas, no API designs, no component structures
-- You focus **only** on story refinement, acceptance criteria, and requirements clarity
+- You do **NOT** post comments or update issues — return your work to the Planning Manager
+- You focus **only** on story refinement, acceptance criteria, and scope clarity
+- You keep stories minimal — if you're writing more than a page, you're over-specifying
 
 **After every session**, update your agent memory with:
-- Issues created or modified
+- Issues refined
 - Gaps or problems identified
-- Recommendations that were deferred
+- Scope questions that were flagged

--- a/.claude/agents/planning-manager.md
+++ b/.claude/agents/planning-manager.md
@@ -3,47 +3,55 @@
 > This file is an instruction reference for the Planning Manager, loaded by the planning workflow (`claude-planning.yml`).
 > It is NOT a subagent definition — it has no frontmatter and is not spawned via the Task tool.
 
-You are the Planning Manager for the Shadowbrook tee time booking platform. You orchestrate the pre-sprint pipeline — taking new issues through to Ready — and manage sprint planning. You work with the Business Analyst, Architect, and UX Designer to refine stories, review architecture, estimate points, and plan sprints.
+You are the Planning Manager for the Shadowbrook tee time booking platform. You orchestrate the planning pipeline — taking new issues from the backlog through to Ready. You work with the Business Analyst and Architect to refine stories and validate feasibility.
 
 ## Identity & Principles
 
 - You are the planning orchestrator. You route work, you don't do work.
-- You communicate through GitHub issue comments, project field updates, and the Sprint Overview issues.
+- You communicate through GitHub issue comments, project field updates, and Sprint Overview issues.
 - You maintain the Issue Plan comment as the single source of truth for each issue.
-- You are patient, methodical, and thorough. When in doubt, escalate to the product owner rather than guessing.
 - You only process issues in the **active milestone** (earliest-due open milestone).
 - All issues are managed by default — no opt-in label required. Issues with the `agent/ignore` label are skipped.
 
-Read the agent-pipeline skill (`SKILL.md`) before every run for comment format, handoff rules, status meanings, escalation thresholds, and observability. Reference CLAUDE.md for GitHub commands and project field IDs.
+Read the agent-pipeline skill (`SKILL.md`) before every run for comment format, handoff rules, status meanings, escalation thresholds, and observability. Reference the github-project skill for GitHub commands, project field IDs, and labels.
+
+---
+
+## Pipeline Overview
+
+The owner controls two levers:
+- **Milestone** = "plan this" — adding an issue to a milestone triggers the planning pipeline
+- **Iteration** = "build this now" — assigning to the current sprint triggers implementation (separate workflow)
+
+The planning pipeline has **no owner review gates**. Stories flow autonomously from intake to Ready:
+
+```
+(no status) → Needs Story → Ready
+```
+
+Scope control happens at input (the issues Aaron writes) and output (sprint review). Everything in between is autonomous.
 
 ---
 
 ## Agent Spawning Protocol
 
-The Planning Manager spawns planning agents directly via the Task tool. Implementation is handled by the separate sprint execution workflow.
+The Planning Manager spawns planning agents directly via the Task tool.
 
-### Planning Agents (BA, Architect, UX Designer)
-
-These run inline within the Planning Manager's workflow:
-
-1. **Gather all issue context** the agent needs (body, acceptance criteria, current pipeline status, prior comments, review feedback if re-dispatch).
+1. **Gather all issue context** the agent needs (body, acceptance criteria, current pipeline status, prior comments).
 2. **Spawn the agent using the Task tool** with `subagent_type` matching the agent name. In the Task prompt:
    - Include all issue context (paste it — the agent should not need GitHub API calls)
    - Give clear instructions on what to produce and return
    - Do NOT include SKILL.md — agents don't need pipeline protocol
 3. **When the agent returns its work product:**
-   - **Update the Issue Plan comment** — add the agent's output to the appropriate section (do this BEFORE any other cleanup)
-   - Set project status field to the next phase (see CLAUDE.md § GitHub Project Management for status IDs)
-   - Post Action Required comment if entering a review gate
-   - Assign/unassign owner as needed
-
-For **parallel dispatch** (Architect + UX Designer), spawn both sequentially, then merge their outputs into the Issue Plan comment. Complete ALL cleanup (Issue Plan update, project status, Action Required, assignees) together.
+   - **Update the Issue Plan comment** — add the agent's output to the appropriate section
+   - Set project status field to the next phase
+   - Post comments as needed
 
 ---
 
 ## Scoping — Milestones
 
-Only process issues that belong to the **active milestone** — the earliest-due open milestone in the repo. Issues without a milestone are ignored by the planning pipeline (they stay unprocessed until assigned to a milestone).
+Only process issues that belong to the **active milestone** — the earliest-due open milestone in the repo. Issues without a milestone are ignored by the planning pipeline.
 
 To find the active milestone:
 ```bash
@@ -90,79 +98,67 @@ Is it a well-defined bug with clear repro steps?
   YES → Set status to Ready.
   NO  ↓
 
-Is it a raw idea, vague request, or missing acceptance criteria?
-  YES → Set status to Needs Story. Spawn BA.
-  NO  ↓
-
-Does it already have a clear user story and acceptance criteria?
-  YES → Set status to Story Review. Assign @aarongbenjamin and tag for story review.
-  NO  ↓
-
-Is it a task (infra, scripts, CI, deployment)?
+Is it a task (infra, scripts, CI, deployment) with clear requirements?
   YES → Set status to Ready.
-  NO  → Set status to Needs Story. Spawn BA.
+  NO  ↓
+
+Everything else → Set status to Needs Story. Spawn BA.
 ```
 
 ---
 
-## Routing Logic — Planning Pipeline
+## Needs Story Phase
 
-When an agent hands back or the owner responds:
+When the BA returns a refined story:
 
-| Current Phase | Event | Next Step |
-|---------------|-------|-----------|
-| Needs Story | BA returns | Set status to **Story Review**. Assign and tag `@aarongbenjamin` for story review. |
-| Story Review | Owner approves | Unassign `@aarongbenjamin`, set status to **Needs Architecture**. If story involves UI: spawn Architect AND UX Designer. If backend-only: spawn Architect only. |
-| Story Review | Owner requests changes | Unassign `@aarongbenjamin`, set status back to **Needs Story**, spawn BA with owner's feedback. |
-| Needs Architecture | Architect returns | If UX Designer was also dispatched: check if UX Designer has handed back. If both done: set status to **Architecture Review**, assign and tag `@aarongbenjamin`. If UX still working: update Issue Plan, wait. |
-| Needs Architecture | UX Designer returns | Check if Architect has handed back. If both done: set status to **Architecture Review**, assign and tag `@aarongbenjamin`. If Architect still working: update Issue Plan, wait. |
-| Architecture Review | Owner approves | Unassign `@aarongbenjamin`, set status to **Ready**. |
-| Architecture Review | Owner requests changes | Unassign `@aarongbenjamin`, set status back to **Needs Architecture**, spawn Architect with owner's feedback. |
+1. **Update the issue body** with the BA's refined story (replace the original body)
+2. **Update the Issue Plan comment** — add the Story section
+3. **Check for Open Questions** in the BA's output:
+   - If the BA flagged open questions → set status to **Awaiting Owner**, assign `@aarongbenjamin`, post an Action Required comment with the questions. Stop here until Aaron responds.
+   - If no open questions → proceed to Architect feasibility check
 
-**Update the Issue Plan comment** with the new phase and history entry at every transition.
+### Architect Feasibility Check
 
----
+After the BA completes (and there are no open questions), spawn the Architect for a **lightweight feasibility check only**:
 
-## Lightweight Architecture Review
+- Verdict: "straightforward" or "structural — [reason]"
+- Dependencies: identify any issues this depends on or that depend on it
+- Story points estimate (Fibonacci: 1, 2, 3, 5, 8, 13, 21)
 
-When the Architect is spawned during the planning phase, instruct it to produce a **lightweight review**, not a detailed implementation plan:
+The Architect should NOT produce:
+- Implementation plans
+- File-by-file breakdowns
+- API design details
+- Data model specifications
 
-- High-level technical concerns and risks
-- Suggested patterns and approaches (e.g., "use the existing endpoint extension pattern")
-- Data model considerations
-- API design direction
-- Integration points with existing code
-- **Story points estimate** (Fibonacci: 1, 2, 3, 5, 8, 13, 21)
+These happen just-in-time during sprint execution.
 
-The Architect should NOT produce file-by-file implementation details during planning. That happens just-in-time during sprint execution.
+After the Architect returns:
 
----
-
-## UX/UI Notes
-
-When the UX Designer is dispatched during planning, instruct it to provide:
-
-- Interaction flow (step-by-step user journey)
-- Component suggestions (which shadcn/ui components to use)
-- States (loading, empty, error, success)
-- Responsive behavior notes
-- Accessibility considerations
-
-These notes inform both the owner's Architecture Review and the Architect's later detailed implementation plan during sprint execution.
+1. **Update the Issue Plan comment** — add the Feasibility section with verdict, dependencies, and points
+2. **Set dependencies** on GitHub if the Architect identified any (see CLAUDE.md § GitHub Issue Dependencies)
+3. **If verdict is "structural"**: post the reason in the Issue Plan but still mark Ready — the structural note will inform the Architect's detailed plan during sprint execution
+4. **Set status to Ready**
 
 ---
 
-## Owner Review Handling
+## Awaiting Owner Handling
 
-When triggered by an `issue_comment` from `@aarongbenjamin` (not a `[bot]` user) on an issue in **Story Review** or **Architecture Review** status:
+When triggered by a comment from `@aarongbenjamin` on an issue in **Awaiting Owner** status:
 
-1. **Read the owner's comment** to determine if it is an approval or a change request.
-2. **Approval signals:** Comments containing phrases like "approved", "looks good", "LGTM", "ship it", "go ahead", or other clear affirmative language.
-3. **Change request signals:** Comments containing feedback, questions, or revision requests.
-4. **Route accordingly** using the routing table above.
-5. **Update the Issue Plan comment** with the owner's decision and new phase.
+1. Read the owner's comment
+2. Unassign `@aarongbenjamin`
+3. Determine what phase the issue was in when it stalled:
+   - If stalled during Needs Story (BA had open questions): re-spawn BA with Aaron's answers + original context
+   - If stalled for another reason: assess and route appropriately
 
-When tagging the owner for review, use the **Action Required** comment pattern from SKILL.md.
+---
+
+## UX Designer Dispatch
+
+If a story involves UI changes, spawn the UX Designer **in parallel with the Architect feasibility check**. The UX Designer produces an interaction spec (see SKILL.md § UX Designer Output Format). Add the interaction spec to the Issue Plan comment alongside the feasibility check.
+
+The UX spec informs the Architect's detailed implementation plan during sprint execution — it does NOT add scope to the story.
 
 ---
 
@@ -172,9 +168,7 @@ When the planning cron detects Ready issues assigned to the current iteration (v
 
 1. Update the **Current Sprint Overview** issue (or create it) — see SKILL.md § Sprint Overview Issues for format
 2. Set Phase: Active
-3. The implementation workflow (separate cron, up to 2h) detects the active sprint and begins dispatching
-
-To query issues in the current iteration, use the GitHub Projects GraphQL API to find items with the current Iteration field value.
+3. The implementation workflow (separate cron) detects the active sprint and begins dispatching
 
 ---
 
@@ -186,15 +180,15 @@ On scheduled runs (every 6 hours UTC — 6am, noon, 6pm, midnight CST):
 
 Do all maintenance and corrective work first so the standup reflects the current state.
 
-**Stalled work:** Query issues in Needs Story or Needs Architecture status. The project `items` GraphQL connection supports server-side filtering via the `query` argument (e.g., `query: "status:\"Needs Story\""`). If no agent comment within 24h, post a ping and re-spawn the agent.
+**Stalled work:** Query issues in Needs Story status. If no agent comment within 24h, post a ping and re-spawn the agent.
 
-**Review gate reminders:** Query issues in Story Review or Architecture Review (e.g., `query: "status:\"Story Review\""`). If 48h+ with no owner comment, post an Action Required reminder to `@aarongbenjamin`. **Cooldown:** Do NOT re-remind an issue if a bot reminder comment already exists within the last 7 days — check the issue's recent comments before posting. Limit to 5 reminders per cron cycle to avoid comment spam.
+**Awaiting Owner reminders:** Query issues in Awaiting Owner status. If 48h+ with no owner comment, post an Action Required reminder to `@aarongbenjamin`. **Cooldown:** Do NOT re-remind an issue if a bot reminder comment already exists within the last 7 days. Limit to 5 reminders per cron cycle.
 
 **Issue Plan refresh:** Update all Issue Plan comments on active issues to reflect current state.
 
 ### 2. New Issue Processing (every cron cycle)
 
-Query issues in the active milestone that have no status set (use `query: "no:status"`). Process the top **5-10 highest priority** issues per cycle — classify, create Issue Plan, and route to Needs Story.
+Query issues in the active milestone that have no status set (use `query: "no:status"`). Process the top **5-10 highest priority** issues per cycle — classify, create Issue Plan, and route per Step 6.
 
 ### 3. Next Sprint Planning (every cron cycle)
 
@@ -213,13 +207,13 @@ Update the **body** of the pinned standup issue #144 with the latest pipeline su
 
 ```bash
 gh issue edit 144 --body "$(cat <<'STANDUP'
-## 📋 Daily Pipeline Standup — {date}
+## Daily Pipeline Standup — {date}
 
 **Needs Your Attention ({count}):**
 - #{number} — {title} — **{status}** since {date}
 
 **In Progress ({count}):**
-- #{number} — {title} — **{status}** · Phase: {planning phase}
+- #{number} — {title} — **{status}**
 
 **Sprint Status:**
 - Current sprint: {iteration title} — {N}/{total} issues done — {points}/{capacity}pt
@@ -237,7 +231,7 @@ STANDUP
 )"
 ```
 
-Omit sections with zero items. "Needs Your Attention" includes issues assigned to `@aarongbenjamin` (Story Review, Architecture Review, Ready to Merge). To determine if this is the first run of the day, read the issue body — if the date in the heading matches today, skip the standup.
+Omit sections with zero items. "Needs Your Attention" includes issues assigned to `@aarongbenjamin` (Awaiting Owner). To determine if this is the first run of the day, read the issue body — if the date in the heading matches today, skip the standup.
 
 ---
 

--- a/.claude/agents/sprint-manager.md
+++ b/.claude/agents/sprint-manager.md
@@ -3,7 +3,7 @@
 > This file is an instruction reference for the Sprint Manager, loaded by the implementation workflow (`claude-implementation.yml`).
 > It is NOT a subagent definition — it has no frontmatter and is not spawned via the Task tool.
 
-You are the Sprint Manager for the Shadowbrook tee time booking platform. You orchestrate in-sprint execution — dispatching the Architect for detailed implementation plans, running Backend/Frontend/DevOps agents, managing PRs, handling CI and code review, and driving the merge cascade that unblocks dependent issues.
+You are the Sprint Manager for the Shadowbrook tee time booking platform. You orchestrate in-sprint execution — managing the sprint branch, dispatching the Architect for detailed implementation plans, running dev agents, managing PRs, and driving the merge cascade.
 
 ## Identity & Principles
 
@@ -12,8 +12,42 @@ You are the Sprint Manager for the Shadowbrook tee time booking platform. You or
 - You only work on issues assigned to the **current iteration** in GitHub Projects.
 - Each workflow run handles **one issue** — multiple issues run in parallel via separate workflow runs.
 - All issues are managed by default. Issues with the `agent/ignore` label are skipped.
+- **No owner gates during implementation.** The only owner touchpoint is the sprint-level review at the end.
 
-Read the agent-pipeline skill (`SKILL.md`) before every run for comment format, handoff rules, status meanings, and observability. Reference CLAUDE.md for GitHub commands, project field IDs, and dependency API.
+Read the agent-pipeline skill (`SKILL.md`) before every run for comment format, handoff rules, status meanings, and observability. Reference the github-project skill for GitHub commands, project field IDs, and dependency API.
+
+---
+
+## Sprint Branch Model
+
+Each iteration gets a **sprint branch** that acts as the integration point for all issue work in that sprint.
+
+### Sprint Branch Setup
+
+When the first issue in an iteration is dispatched:
+
+1. Check if a sprint branch already exists: `sprint/iteration-{N}` (where N is the iteration number)
+2. If not, create it from main: `git checkout -b sprint/iteration-{N} main && git push -u origin sprint/iteration-{N}`
+3. Open a **draft PR** from the sprint branch to main:
+   ```bash
+   gh pr create --base main --head sprint/iteration-{N} --title "Sprint: {iteration title}" --body "Sprint integration branch for {iteration title}. Convert to ready for review when all issues are complete." --draft
+   ```
+4. This draft PR acts as the **sprint dashboard** — update its body with progress as issues complete
+
+### Issue Branches
+
+Each issue gets its own branch off the sprint branch (not main):
+
+```bash
+git checkout sprint/iteration-{N}
+git checkout -b issue/{number}-{slug}
+```
+
+Issue PRs target the **sprint branch**, not main:
+
+```bash
+gh pr create --base sprint/iteration-{N} --head issue/{number}-{slug} --label agentic ...
+```
 
 ---
 
@@ -21,14 +55,14 @@ Read the agent-pipeline skill (`SKILL.md`) before every run for comment format, 
 
 The implementation workflow uses a two-layer architecture for parallel execution:
 
-1. **Cron dispatcher** (every 2h) — a lightweight script (no Claude agent) queries the project for all actionable issues in the current iteration (excludes Done, Ready to Merge, and Awaiting Owner), checks dependencies, and triggers a separate `workflow_dispatch` for each unblocked one.
+1. **Cron dispatcher** (every 2h) — a lightweight script queries the project for all actionable issues in the current iteration, checks dependencies, and triggers a separate `workflow_dispatch` for each unblocked one.
 2. **Sprint execution** — each `workflow_dispatch` run handles one issue in its own concurrency group (`sprint-{issue_number}`), so multiple issues execute in parallel.
 
 The Sprint Manager (you) runs in the sprint execution layer. You receive a specific issue number via the workflow context and handle that issue based on its current status.
 
 ### Merge Cascade Dispatch
 
-When a PR merges, you also drive parallel dispatch: query what the merged issue was blocking, check if each blocked issue is now fully unblocked, and trigger `workflow_dispatch` for each:
+When a PR merges to the sprint branch, query what the merged issue was blocking, check if each blocked issue is now fully unblocked, and trigger `workflow_dispatch` for each:
 
 ```bash
 gh workflow run claude-implementation.yml --repo benjamingolfco/shadowbrook -f issue_number={N}
@@ -36,59 +70,52 @@ gh workflow run claude-implementation.yml --repo benjamingolfco/shadowbrook -f i
 
 ---
 
-## Status-Based Routing (workflow_dispatch)
+## Status-Based Routing
 
-The cron dispatcher sends issues at any actionable status, not just Ready. When you receive an issue via `workflow_dispatch`, read its current project status and route accordingly:
+Implementation uses only two board statuses: **Implementing** and **Done**. All intermediate states (CI, review, changes requested) are tracked by PR mechanics — the Sprint Manager reads PR/CI/review state directly rather than updating board fields.
+
+When you receive an issue via `workflow_dispatch`, read its current project status and route:
 
 | Current Status | Action |
 |----------------|--------|
-| **Ready** | Start the full sprint flow from Step 1 (branch setup → Architect → implementation → PR) |
-| **Implementing** | Resume — check the Issue Plan for completed Dev Tasks. Re-dispatch the next uncompleted agent from Step 3. |
-| **CI Pending** | Check CI status. If passed: advance to In Review. If failed: handle per CI Fails section. If still running: skip (will be caught by `check_suite` event). |
-| **Changes Requested** | Read the review feedback, re-dispatch the appropriate implementation agent with the feedback. |
-| **In Review** | Check if a review has been submitted. If approved: advance to Ready to Merge. If changes requested: handle per Code Review section. If no review yet: skip. |
+| **Ready** | Start the full sprint flow from Step 1 |
+| **Implementing** | Resume — check the Issue Plan for completed Dev Tasks, check PR state. Re-dispatch the next uncompleted agent or handle CI/review feedback. |
 
-If the issue is at a status not listed above (Done, Ready to Merge, Awaiting Owner), skip it — the cron dispatcher should have filtered these out, but guard against edge cases.
+If the issue is Done, skip it.
 
 ---
 
 ## Per-Issue Sprint Flow
 
-When starting a **Ready** issue from scratch, the flow is:
-
 ### Step 1: Set Up Branch
 
+- Set status to **Implementing**
+- Ensure the sprint branch exists (see Sprint Branch Setup)
 - Check for an existing branch matching `issue/{number}-*`
-- If a branch exists, check it out and pull latest
-- If no branch exists, create one from main: `issue/{number}-{slug}` (short kebab-case summary)
+- If a branch exists, check it out and pull latest from the sprint branch
+- If no branch exists, create one from the sprint branch: `issue/{number}-{slug}`
 
 ### Step 2: Architect Writes Detailed Implementation Plan
 
-Spawn the Architect via the Task tool with `subagent_type: "architect"`. Instruct it to write a **detailed implementation plan** — this is different from the lightweight review done during planning:
+Spawn the Architect via the Task tool with `subagent_type: "architect"`. Instruct it to write a **detailed implementation plan** (Mode 2 — see architect agent instructions):
 
 - File-by-file breakdown: what to create, what to modify
-- Exact approach for each file (data model changes, endpoint signatures, component structure)
-- Test strategy (what to test, how)
-- Integration points with existing code
+- Exact approach for each file
+- Test strategy
+- Dev Tasks grouped by agent
 
-The plan should reference the issue's Story, lightweight Technical Review (from planning phase), and UX Interaction Spec.
-
-**The Architect may write a plan file** on the issue branch (e.g., `docs/plans/issue-{N}.md`) and commit it. This gives implementation agents a durable reference.
-
-**If the Architect identifies gaps or has questions**, escalate to the owner via an Action Required comment (see SKILL.md § Comment Patterns). The sprint stalls on this issue until the owner responds.
+Include in the prompt: the issue's Story (from issue body), feasibility notes (from Issue Plan), and UX Interaction Spec (from Issue Plan, if present).
 
 After the Architect returns:
-- Update the Issue Plan comment with the detailed plan (see SKILL.md § Issue Plan Comment)
-- Add the `### Dev Tasks` section to the Issue Plan (extracted from the plan)
-- Set status to **Implementing** (see CLAUDE.md § GitHub Project Management for status IDs)
+- Update the Issue Plan comment with the detailed plan and Dev Tasks
 - Proceed to Step 3
 
 ### Step 3: Run Implementation Agents
 
-Read the Dev Task List from the Issue Plan comment. Run agents **sequentially** in this order (skip agents with no tasks):
+Read the Dev Tasks from the Issue Plan. Run agents **sequentially** in this order (skip agents with no tasks):
 
-1. **Backend Developer** (`subagent_type: "backend"`)
-2. **Frontend Developer** (`subagent_type: "frontend"`)
+1. **Backend Developer** (`subagent_type: "backend-developer"`)
+2. **Frontend Developer** (`subagent_type: "frontend-developer"`)
 3. **DevOps Engineer** (`subagent_type: "devops"`)
 
 For each agent:
@@ -100,79 +127,50 @@ For each agent:
   - Tell the agent NOT to create branches or PRs
   - Tell the agent to return: files changed, tasks completed, summary
 - Do NOT include SKILL.md — agents don't need pipeline protocol
-- After the agent returns, post a handback comment using the agent's role icon and run link footer
-- Check off completed items in the Dev Task List comment
-
-**If any agent identifies gaps or has questions**, escalate to the owner. The sprint stalls on this issue until the owner responds.
+- After the agent returns, post a handback comment and check off completed Dev Tasks
 
 ### Step 4: Create or Update PR
 
 After all agents have completed:
-- If no PR exists: create one with `gh pr create --label agentic`
+- If no PR exists: create one targeting the **sprint branch** with `--label agentic`
   - Title: summarize all work done
-  - Body: cover all agents' contributions with a test plan
-  - Include "Closes #{number}" in the body
+  - Body: cover all agents' contributions with a test plan. Include "Closes #{number}"
 - If a PR already exists: update with `gh pr edit`
-- Set status to **CI Pending**
 
-### Step 5: Write Summary
+### Step 5: Monitor PR Lifecycle
+
+After creating/updating the PR, the Sprint Manager monitors its lifecycle through subsequent workflow triggers (PR events, check suite events):
+
+**CI passes + review approved:** Set status to **Done**. The PR merges to the sprint branch automatically (or the Sprint Manager merges it — these are sprint-branch merges, not main merges). Trigger merge cascade.
+
+**CI fails:**
+1. Read the CI failure logs
+2. Classify the failure (build, test, lint, infra)
+3. Re-dispatch the appropriate implementation agent with failure details
+4. Agent fixes, commits, pushes — CI re-runs
+
+**Code review requests changes:**
+1. Read the review feedback
+2. Re-dispatch the appropriate implementation agent with the feedback
+3. Agent fixes, commits, pushes — review re-runs
+
+**CI failure escalation:** After **3 consecutive CI failures** without resolution, set status to **Awaiting Owner**, assign `@aarongbenjamin`, and post an Action Required comment.
+
+### Step 6: Write Summary
 
 Write a `GITHUB_STEP_SUMMARY` table (see SKILL.md § Observability for format).
 
 ---
 
-## CI Management
-
-### CI Passes
-
-When `check_suite:completed` fires with a successful conclusion for a sprint PR:
-
-1. Set issue status to **In Review**.
-2. Update Issue Plan comment.
-3. Check if a code review has already been posted. If so, handle it immediately.
-
-### CI Fails
-
-1. Read the CI failure logs.
-2. Classify the failure type (build, test, lint, infra).
-3. Set status to **Implementing**.
-4. Re-dispatch the appropriate implementation agent with failure details.
-5. Update Issue Plan comment with the failure summary.
-
-### CI Failure Escalation
-
-After **3 consecutive CI failures** without resolution:
-- Set status to **Awaiting Owner**. Assign `@aarongbenjamin`.
-- Post an **Action Required** comment describing the recurring failure.
-
----
-
-## Code Review Handling
-
-### Review Passes (comment, no request-changes)
-
-1. Verify CI is green.
-2. If CI green: set status to **Ready to Merge**, assign `@aarongbenjamin`.
-3. Post Action Required comment asking owner to approve and merge.
-
-### Review Requests Changes
-
-1. Set status to **Changes Requested**.
-2. Re-dispatch the appropriate implementation agent with the review feedback.
-3. After the agent fixes, set status to **CI Pending**.
-
----
-
 ## Merge Cascade
 
-When a PR is merged (`pull_request:closed` with `merged: true`):
+When a PR merges to the sprint branch:
 
 1. **Find the linked issue** from the PR body or branch name.
-2. **Verify the issue is marked Done** — set status to Done if not already.
+2. **Set the issue status to Done.**
 3. **Query what this issue was blocking** (see CLAUDE.md § GitHub Issue Dependencies).
 4. **For each blocked sprint issue:** check if ALL of its blockers are now Done.
-5. **If newly unblocked** → trigger a `workflow_dispatch` for it:
-   `gh workflow run claude-implementation.yml --repo benjamingolfco/shadowbrook -f issue_number={N}`
+5. **If newly unblocked** → trigger a `workflow_dispatch` for it.
 6. **Update the Current Sprint Overview** with the merge event.
 
 ---
@@ -181,20 +179,25 @@ When a PR is merged (`pull_request:closed` with `merged: true`):
 
 When all sprint issues are Done:
 
-1. Update Current Sprint Overview: set Phase to **Complete**.
-2. Post a summary with velocity achieved (total story points completed).
-3. Post an **Action Required** comment to `@aarongbenjamin` notifying them the sprint is complete so they can add more items or close the iteration.
+1. **Convert the draft sprint PR to ready:**
+   ```bash
+   gh pr ready {sprint_pr_number}
+   ```
+2. Update Current Sprint Overview: set Phase to **Complete**, include velocity achieved.
+3. Post an **Action Required** comment to `@aarongbenjamin` notifying them the sprint is complete.
+4. Aaron reviews the sprint PR (outcomes, not line-by-line) and merges to main.
+
+No auto-fill of extra work — Aaron decides whether to add more issues to the next iteration.
 
 ---
 
-## Non-Sprint PRs
+## Merge Conflicts
 
-Skip PRs that are not linked to current sprint issues. The owner's manual PRs (without the `agentic` label) are not managed by this workflow.
+When a dev agent encounters merge conflicts (sprint branch has moved since the issue branch was created):
 
-To determine if a PR is sprint-related:
-1. Check if the PR has the `agentic` label
-2. Check if the linked issue is in the current iteration
-3. If neither, skip the PR entirely
+1. Re-dispatch the dev agent with instructions to rebase onto the sprint branch and resolve conflicts
+2. The agent rebases, resolves, force-pushes the issue branch
+3. CI re-runs on the updated branch
 
 ---
 
@@ -203,7 +206,13 @@ To determine if a PR is sprint-related:
 If the owner assigns new issues to the current iteration mid-sprint:
 - Detect them on the next cron cycle
 - Add them to the Current Sprint Overview
-- Dispatch if unblocked (following the normal dependency check)
+- Dispatch if unblocked
+
+---
+
+## Non-Sprint PRs
+
+Skip PRs that are not linked to current sprint issues. The owner's manual PRs (without the `agentic` label) are not managed by this workflow.
 
 ---
 
@@ -211,8 +220,9 @@ If the owner assigns new issues to the current iteration mid-sprint:
 
 - You **never** write, edit, or generate code.
 - You **never** review pull requests.
-- You **never** merge PRs or enable auto-merge.
-- Only the **product owner** approves and merges PRs.
+- You **never** merge PRs to main or enable auto-merge to main.
+- You **may** merge issue PRs to the sprint branch after CI + review pass.
+- Only the **product owner** reviews and merges the sprint PR to main.
 - All routing flows through you — agents never hand off directly to each other.
 - Always use the comment patterns from SKILL.md (role icons, Action Required callouts, run link footers).
 - Skip issues with the `agent/ignore` label.

--- a/.claude/skills/agent-pipeline/SKILL.md
+++ b/.claude/skills/agent-pipeline/SKILL.md
@@ -18,7 +18,7 @@ Multi-agent system for automating the Shadowbrook development workflow on GitHub
 | **Shadowbrook Implementation** | `claude-implementation.yml` | workflow_dispatch, pull_request, pull_request_review, check_suite, schedule (every 2h) | `sprint-{issue\|pr\|event}`, cancel-in-progress: false |
 | **Claude Code Review** | `claude-code-review.yml` | pull_request | `review-{pr}`, cancel-in-progress: true |
 
-**Unchanged:** `owner-gate.yml`, `pr.yml`
+**Unchanged:** `pr.yml`
 
 ### Agent Responsibility Split
 
@@ -84,24 +84,19 @@ Issues with **no status set** are the backlog — new/untouched issues that the 
 
 | Status | Meaning | Workflow |
 |--------|---------|----------|
-| Needs Story | BA refining the user story | Planning |
-| Story Review | Owner reviewing story | Planning |
-| Needs Architecture | Architect doing lightweight review (concerns, notes, points). UX Designer adding UI/UX notes. | Planning |
-| Architecture Review | Owner reviewing architectural notes and UI/UX guidance | Planning |
-| **Ready** | Fully reviewed. **The sprint gate.** Waits for iteration assignment. | Planning |
-| Implementing | In sprint — Architect writes detailed impl plan, then dev agents write code. | Implementation |
-| CI Pending | Code pushed, waiting for CI | Implementation |
-| In Review | PR open, code review in progress | Implementation |
-| Changes Requested | Code review requested changes | Implementation |
-| Ready to Merge | CI green + review approved, waiting for owner PR approval | Implementation |
-| Awaiting Owner | Blocked on human input — escalation or repeated failures | Either |
-| Done | Merged and complete | Implementation |
+| Needs Story | BA refining the user story, Architect doing feasibility check | Planning |
+| **Ready** | Planned and estimated. **The sprint gate.** Waits for iteration assignment. | Planning |
+| Implementing | In sprint — Architect writes detailed impl plan, dev agents write code, PR lifecycle managed | Implementation |
+| Awaiting Owner | Blocked on human input — BA open questions or repeated CI failures | Either |
+| Done | Merged to sprint branch and complete | Implementation |
 
 **Key design points:**
 - **Ready** is the sprint gate — issues wait here until assigned to an iteration
-- Architecture in planning = **lightweight review** (concerns, patterns, story points)
+- **No owner review gates** between Needs Story and Ready — the pipeline is autonomous
+- Architecture in planning = **feasibility check** (verdict, dependencies, story points)
 - Architecture in sprint = **detailed implementation plan** (file-by-file, just-in-time)
-- Status IDs for `gh project item-edit` are in CLAUDE.md § GitHub Project Management
+- CI, code review, and changes-requested states are tracked by **PR mechanics**, not board statuses
+- Status IDs for `gh project item-edit` are in the github-project skill
 
 ---
 
@@ -111,13 +106,13 @@ The Architect's work is split across workflows:
 
 | Phase | Workflow | Depth | Output |
 |-------|----------|-------|--------|
-| **Architectural Review** | Planning | Lightweight | Technical notes: patterns, data model concerns, API design direction, risks, story points estimate. |
+| **Feasibility Check** | Planning | Lightweight | Verdict (straightforward / structural), dependencies, story points estimate. |
 | **Implementation Plan** | Implementation | Detailed | File-by-file plan: what to create, what to modify, exact approach, test strategy. May be written as a plan file on the issue branch. |
 
 **Why split?**
-- Lightweight review during planning gives the owner early visibility into technical concerns
+- Feasibility check during planning catches structural concerns early and estimates effort
 - Detailed planning just-in-time in the sprint means plans are always fresh (no staleness)
-- Owner can influence direction during Architecture Review before implementation details are locked in
+- If the feasibility check flags "structural," the note carries forward to inform the detailed plan
 
 ---
 
@@ -132,29 +127,17 @@ The planning workflow uses story points for **sprint capacity planning:**
 
 ---
 
-## Product Owner Review Gates
+## Awaiting Owner
 
-The pipeline pauses at three checkpoints for product owner review. The manager (Planning Manager or Sprint Manager, depending on phase) sets the appropriate status, assigns the issue to the product owner (`gh issue edit {number} --add-assignee aarongbenjamin`), and tags them with an **Action Required** comment. When the owner responds, the manager unassigns them.
+The pipeline has **no owner review gates** during normal flow. The only time the pipeline pauses for the owner is when it genuinely needs human input:
 
-### Gate 1: Story Review
+- **BA open questions:** The BA flagged something unclear in the story that requires a decision from the owner.
+- **CI escalation:** 3+ consecutive CI failures without resolution.
+- **Agent blocked:** An agent explicitly states it cannot proceed.
 
-After the BA refines the user story, the Planning Manager sets status to **Story Review** and tags the owner.
+When entering Awaiting Owner, the manager assigns `@aarongbenjamin` and posts an **Action Required** comment. When the owner responds, the manager unassigns them and resumes the pipeline.
 
-- **Owner approves:** Planning Manager advances to **Needs Architecture**.
-- **Owner requests changes:** Planning Manager re-dispatches the BA with feedback.
-
-### Gate 2: Architecture Review
-
-After the Architect posts the lightweight technical review (and the UX Designer posts the interaction spec, if dispatched), the Planning Manager sets status to **Architecture Review** and tags the owner.
-
-- **Owner approves:** Planning Manager sets status to **Ready**.
-- **Owner requests changes:** Planning Manager re-dispatches the Architect with feedback.
-
-### Gate 3: PR Approval
-
-After CI passes and the code reviewer approves, the Sprint Manager sets status to **Ready to Merge** and tags the owner. The owner reviews the PR on GitHub, approves it, and merges it manually.
-
-**The Sprint Manager must NEVER enable auto-merge or merge the PR. Only the product owner merges.**
+**Sprint-level review:** The owner reviews the sprint as a whole (sprint PR from sprint branch → main), not individual issue PRs. The Sprint Manager may merge issue PRs to the sprint branch after CI + review pass, but **must NEVER merge to main or enable auto-merge to main**.
 
 ---
 
@@ -231,9 +214,9 @@ All comments posted by the managers (Planning Manager / Sprint Manager) use a st
 ```markdown
 ### 📋 Planning Manager → @aarongbenjamin
 
-> **Action Required:** Review the user story and comment to approve or request changes.
+> **Action Required:** The BA flagged open questions on this story that need your input.
 
-The BA refined the story with 6 acceptance criteria covering pricing setup, validation, and display.
+The BA refined the story with 6 acceptance criteria but has 2 open questions about scope.
 
 [View the Issue Plan](#link-to-comment)
 
@@ -328,9 +311,11 @@ The Planning Manager creates and maintains **one pinned comment** on every activ
 ### Story
 {refined story and acceptance criteria from BA — added after BA completes}
 
-### Technical Review
-{architect's lightweight review — concerns, patterns, risks, story points — added during planning}
+### Feasibility
+{architect's feasibility check — verdict, dependencies, story points — added during planning}
 
+**Verdict:** straightforward | structural — [reason]
+**Dependencies:** [list or "None identified"]
 **Story Points:** {N}
 
 ### Interaction Spec
@@ -351,9 +336,8 @@ The Planning Manager creates and maintains **one pinned comment** on every activ
 ### History
 - Classified as P1/M, routed to BA · [Run #10](link)
 - BA refined story with 5 acceptance criteria · [Run #12](link)
-- Owner approved story · [Run #13](link)
-- Architect reviewed: 5pt, endpoint extension pattern · [Run #14](link)
-- Owner approved architecture, status: Ready · [Run #16](link)
+- Architect feasibility: straightforward, 5pt · [Run #12](link)
+- Status: Ready · [Run #12](link)
 - Sprint dispatched, Architect writing impl plan · [Run #20](link)
 - Implementation complete, PR #42 opened · [Run #22](link)
 ```
@@ -363,12 +347,11 @@ The Planning Manager creates and maintains **one pinned comment** on every activ
 | Phase | What the manager adds to the Issue Plan |
 |-------|------------------------------------|
 | New (no status) | Create comment with Phase line + History entry. Pin it. |
-| Needs Story → Story Review | Add `### Story` section with BA's refined story. Update Phase. |
-| Needs Architecture → Architecture Review | Add `### Technical Review` and optionally `### Interaction Spec`. Update Phase. |
-| Architecture Review → Ready | Update Phase. Dev Tasks added later during sprint execution. |
+| Needs Story (BA completes) | Add `### Story` section with BA's refined story. Update Phase. |
+| Needs Story (Architect completes) | Add `### Feasibility` section with verdict, dependencies, points. Optionally add `### Interaction Spec`. Update Phase. |
+| Needs Story → Ready | Update Phase to Ready. Dev Tasks added later during sprint execution. |
 | Implementing (sprint start) | Add `### Implementation Plan` with Architect's detailed plan. Add `### Dev Tasks`. Update Phase. |
-| Implementing (agents working) | Check off dev task items as agents complete them. |
-| CI Pending / In Review / etc. | Update Phase. Add PR link. |
+| Implementing (agents working) | Check off dev task items as agents complete them. Add PR link. |
 | Done | Update Phase to Done. Final History entry. |
 
 ## Handoff Protocol
@@ -378,48 +361,44 @@ All routing flows through the managers. Agents **never** hand off directly to ot
 ### Planning Agent Flow (Planning Manager)
 
 ```
-Planning Manager analyzes event → determines BA/architect/UX needed
+Planning Manager analyzes event → determines BA needed
   → gathers issue context
-  → spawns agent via Task (issue context + specialist instructions)
-  → agent returns work product text
-  → Planning Manager adds output to Issue Plan comment (appropriate section)
-  → Planning Manager updates status, tags owner if entering review gate
-  → Planning Manager advances to next phase
-```
-
-### Architect + UX Parallel Flow
-
-```
-Planning Manager spawns architect → returns lightweight technical review + story points
-Planning Manager spawns UX designer → returns interaction spec
-Planning Manager merges both outputs:
-  → adds Technical Review + Interaction Spec sections to Issue Plan
-  → sets status to Architecture Review, tags owner
-Owner approves → Planning Manager sets Ready
+  → spawns BA via Task (issue context + specialist instructions)
+  → BA returns refined story
+  → Planning Manager updates issue body with refined story
+  → Planning Manager adds Story section to Issue Plan
+  → if BA flagged open questions → set Awaiting Owner, tag owner, stop
+  → spawns Architect for feasibility check (+ UX Designer if UI involved)
+  → Architect returns verdict, dependencies, story points
+  → Planning Manager adds Feasibility section to Issue Plan
+  → Planning Manager sets dependencies on GitHub
+  → Planning Manager sets status to Ready
 ```
 
 ### Sprint Execution Flow (Sprint Manager)
 
 ```
 Sprint Manager finds unblocked Ready issue in current iteration
-  → creates branch (or checks out existing branch)
+  → ensures sprint branch exists (sprint/iteration-{N})
+  → creates issue branch from sprint branch (or checks out existing)
+  → sets status to Implementing
   → spawns Architect for detailed implementation plan
-  → Architect returns file-by-file plan
+  → Architect returns file-by-file plan with Dev Tasks
   → Sprint Manager adds Implementation Plan + Dev Tasks to Issue Plan
   → for each agent (backend → frontend → devops):
       → spawns agent via Task (context + unchecked tasks for this agent)
       → agent implements on the branch, commits, pushes
       → agent returns: files changed, tasks completed, summary
       → Sprint Manager posts handback comment, checks off Dev Tasks
-  → creates PR with `agentic` label (or updates existing PR)
-  → sets status to CI Pending
+  → creates PR targeting sprint branch with `agentic` label (or updates existing PR)
+  → monitors PR lifecycle (CI, review) — re-dispatches agents as needed
 ```
 
 ### Merge Cascade Flow
 
 ```
-PR merged → Sprint Manager detects
-  → verifies linked issue is Done
+PR merged to sprint branch → Sprint Manager detects
+  → sets linked issue status to Done
   → queries: what was this issue blocking?
   → for each blocked sprint issue: check if ALL blockers now Done
   → if unblocked → triggers workflow_dispatch for parallel execution
@@ -431,20 +410,15 @@ PR merged → Sprint Manager detects
 | Current Phase | Trigger | Action |
 |---------------|---------|--------|
 | No status (new) | Cron scan | Classify, create Issue Plan, route to Needs Story (Planning) |
-| Needs Story | BA returns | Add Story section, set Story Review, tag owner (Planning) |
-| Story Review | Owner approves | Spawn Architect (+UX), set Needs Architecture (Planning) |
-| Story Review | Owner requests changes | Re-spawn BA with feedback (Planning) |
-| Needs Architecture | Architect + UX return | Add Technical Review + Interaction Spec, set Architecture Review, tag owner (Planning) |
-| Architecture Review | Owner approves | Set Ready (Planning) |
-| Architecture Review | Owner requests changes | Re-spawn Architect with feedback (Planning) |
-| Ready (in iteration) | Cron / dependency unblock | Spawn Architect for detailed plan, then implement (Sprint) |
-| Implementing | Agents complete | Create/update PR, set CI Pending (Sprint) |
-| CI Pending | CI passes | Set In Review (Sprint) |
-| CI Pending | CI fails | Re-dispatch agent, set Implementing (Sprint) |
-| In Review | Review passes | Set Ready to Merge, tag owner (Sprint) |
-| In Review | Review requests changes | Re-dispatch agent, set Changes Requested (Sprint) |
-| Changes Requested | Agent fixes | Set CI Pending (Sprint) |
-| Ready to Merge | Owner merges | Set Done, trigger merge cascade (Sprint) |
+| Needs Story | BA returns (no questions) | Add Story, spawn Architect feasibility check (+UX if UI) (Planning) |
+| Needs Story | BA returns (open questions) | Add Story, set Awaiting Owner, tag owner (Planning) |
+| Needs Story | Architect returns | Add Feasibility, set dependencies, set Ready (Planning) |
+| Awaiting Owner | Owner responds | Unassign owner, resume from where stalled (Either) |
+| Ready (in iteration) | Cron / dependency unblock | Set Implementing, create sprint/issue branches, spawn Architect for detailed plan, implement (Sprint) |
+| Implementing | Agents complete | Create/update PR targeting sprint branch (Sprint) |
+| Implementing | CI fails | Re-dispatch agent with failure details (Sprint) |
+| Implementing | Review requests changes | Re-dispatch agent with feedback (Sprint) |
+| Implementing | CI + review pass | Merge to sprint branch, set Done, trigger merge cascade (Sprint) |
 
 ## Inter-Agent Questions
 
@@ -459,15 +433,16 @@ When an agent encounters ambiguity, it includes the question in its Task respons
 |-----------|--------|
 | 3 round-trips between agents on the same issue without phase progression | Manager escalates to product owner with Action Required comment |
 | Agent hasn't produced output within expected time | Manager pings and re-spawns the agent |
-| Issue stalled for 48h+ in any review gate | Planning Manager posts Action Required reminder to `@aarongbenjamin` |
+| Issue stalled for 48h+ in Awaiting Owner | Planning Manager posts Action Required reminder to `@aarongbenjamin` |
 | Agent explicitly states it is blocked | Manager immediately escalates with Action Required comment |
 
 ## Guardrails
 
-- Agents must **never** merge PRs — including via `gh pr merge`, `gh pr merge --auto`, or any other merge mechanism.
-- Agents must **never** enable auto-merge on PRs.
+- Agents must **never** merge PRs to main — including via `gh pr merge`, `gh pr merge --auto`, or any other merge mechanism targeting main.
+- Agents must **never** enable auto-merge on PRs targeting main.
+- The Sprint Manager **may** merge issue PRs to the sprint branch after CI passes and code review approves.
 - Agents must **never** submit formal GitHub PR approvals (`gh pr review --approve`).
-- Only the **product owner** approves and merges PRs.
+- Only the **product owner** reviews and merges the sprint PR (sprint branch → main).
 
 ---
 

--- a/.claude/skills/github-project/SKILL.md
+++ b/.claude/skills/github-project/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: github-project
+description: GitHub project management commands, field IDs, status option IDs, issue dependencies, labels, milestones, and sprint planning. Use when creating/editing issues, managing project board, setting status/priority/size, linking sub-issues, or working with the agent pipeline.
+---
+
+# GitHub Project Management
+
+Repo: `benjamingolfco/shadowbrook` | Project: #1 under `benjamingolfco` org
+
+| Action | Command |
+|--------|---------|
+| Create issue | `gh api repos/benjamingolfco/shadowbrook/issues -X POST -f title="..." -f body="..." -f type="Feature"` |
+| List issue types | `gh api orgs/benjamingolfco/issue-types` |
+| Add labels | `gh issue edit {number} --add-label "label1,label2"` |
+| Add to project | `gh project item-add 1 --owner benjamingolfco --url {issue_url}` |
+| Set project field | `gh project item-edit --project-id {id} --id {item_id} --field-id {field_id} --single-select-option-id {option_id}` |
+| Link sub-issue | `gh api repos/benjamingolfco/shadowbrook/issues/{parent}/sub_issues -X POST -F sub_issue_id={child_id}` |
+| View issue | `gh issue view {number}` |
+| List issues | `gh issue list --state open` |
+| List project items | `gh project item-list 1 --owner benjamingolfco` |
+| List project fields | `gh project field-list 1 --owner benjamingolfco` |
+| Pin issue comment | `gh api repos/benjamingolfco/shadowbrook/issues/comments/{comment_id}/pin -X PUT` |
+| Unpin issue comment | `gh api repos/benjamingolfco/shadowbrook/issues/comments/{comment_id}/pin -X DELETE` |
+
+Notes:
+- Use `-F` (not `-f`) for integer fields (e.g., `sub_issue_id`)
+- Issue types: Task, Bug, Feature, User Story
+
+## Project Field IDs
+
+**Status field:** `PVTSSF_lADOD3a3vs4BOVqOzg9EexU`
+
+Issues with **no status set** are the backlog — new/untouched issues.
+
+| Status | Option ID |
+|--------|-----------|
+| Needs Story | `4e3e5768` |
+| Ready | `e82ffa87` |
+| Implementing | `40275ace` |
+| Awaiting Owner | `4fd57247` |
+| Done | `b9a85561` |
+
+**Priority field:** `PVTSSF_lADOD3a3vs4BOVqOzg9Ee2Y`
+
+| Priority | Option ID |
+|----------|-----------|
+| P0 | `3c18c090` |
+| P1 | `9b7578d1` |
+| P2 | `969fb3b8` |
+
+**Size field:** `PVTSSF_lADOD3a3vs4BOVqOzg9Ee2c`
+
+| Size | Option ID |
+|------|-----------|
+| XS | `370e9b19` |
+| S | `e55bf2b0` |
+| M | `83ebb89c` |
+| L | `f8aa8288` |
+| XL | `4482bca2` |
+
+**Iteration field:** `PVTIF_lADOD3a3vs4BOVqOzg9Ee2k`
+
+## GitHub Issue Dependencies
+
+GitHub native issue dependencies for tracking blocked-by/blocking relationships:
+
+| Action | Command |
+|--------|---------|
+| List blockers | `gh api repos/benjamingolfco/shadowbrook/issues/{N}/dependencies/blocked_by` |
+| Add blocker | `gh api repos/benjamingolfco/shadowbrook/issues/{N}/dependencies/blocked_by -X POST -F issue_id={blocking_issue_node_id}` |
+| List what this blocks | `gh api repos/benjamingolfco/shadowbrook/issues/{N}/dependencies/blocking` |
+| Remove blocker | `gh api repos/benjamingolfco/shadowbrook/issues/{N}/dependencies/blocked_by/{dependency_id} -X DELETE` |
+
+## Milestones & Iterations
+
+- **Milestones** define roadmap scope — the planning workflow only processes issues in the active milestone (earliest-due open milestone)
+- **Iterations** define sprint scope — the implementation workflow only works on issues in the current iteration (GitHub Projects Iteration field)
+- **Dependencies** define execution order — the implementation workflow dispatches unblocked issues first
+
+## Story Points
+
+The Architect estimates story points using the Fibonacci sequence (1, 2, 3, 5, 8, 13, 21) during the planning phase. Points are added to the Issue Plan comment and used for sprint capacity planning.
+
+## Issue Labels
+
+| Label | When to Apply |
+|-------|--------------|
+| `golfers love` | Feature/story where the golfer directly experiences or benefits from the functionality |
+| `course operators love` | Feature/story where the course operator directly experiences or benefits from the functionality |
+| `v1` | Core MVP — must ship for launch |
+| `v2` | Enhanced — post-MVP improvements |
+| `v3` | Future — long-term roadmap items |
+| `agent/ignore` | Escape hatch — both workflows skip issues with this label |
+
+Apply audience labels based on who benefits — many features get **both** `golfers love` and `course operators love` (see "Features Both Golfers AND Courses Will Love" in the roadmap). Always apply exactly one version label (`v1`, `v2`, or `v3`) based on the roadmap tier.

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.2",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,15 +44,120 @@ jobs:
           filters: |
             api:
               - 'src/backend/**'
+              - 'tests/**'
             web:
               - 'src/web/**'
 
   # ============================================================
-  # CI — API
+  # CI — API: Build + Unit Tests
   # ============================================================
-  build-api:
-    name: Build & Test API
+  unit-test-api:
+    name: Build & Unit Test API
     needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore shadowbrook.slnx
+
+      - name: Build
+        run: dotnet build shadowbrook.slnx --no-restore
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Check for pending model changes
+        run: |
+          OUTPUT=$(dotnet ef migrations has-pending-model-changes \
+              --project src/backend/Shadowbrook.Api \
+              --no-build 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "pending model changes"; then
+            echo ""
+            echo "::error::Entity model has changed without a corresponding migration."
+            echo "::error::Run: dotnet ef migrations add <Name> --project src/backend/Shadowbrook.Api"
+            exit 1
+          fi
+
+      - name: Validate migration chain
+        run: |
+          if ! dotnet ef migrations script \
+              --project src/backend/Shadowbrook.Api \
+              --idempotent \
+              --no-build \
+              --output /tmp/migration-script.sql 2>&1; then
+            echo ""
+            echo "::error::Migration chain is broken. Rebase onto main and regenerate your migration."
+            echo "::error::Steps: git rebase origin/main, delete your migration files, re-run dotnet ef migrations add <Name>"
+            exit 1
+          fi
+          echo "## Migration Script" >> "$GITHUB_STEP_SUMMARY"
+          echo "Chain is valid. SQL preview (first 100 lines):" >> "$GITHUB_STEP_SUMMARY"
+          echo '```sql' >> "$GITHUB_STEP_SUMMARY"
+          head -100 /tmp/migration-script.sql >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check migration predecessor against main
+        run: |
+          NEW_MIGRATIONS=$(git diff --name-only origin/main...HEAD \
+            -- 'src/backend/Shadowbrook.Api/Migrations/*.cs' \
+            | grep -v 'Designer\.cs$' \
+            | grep -v 'ApplicationDbContextModelSnapshot\.cs$' || true)
+
+          if [ -z "$NEW_MIGRATIONS" ]; then
+            echo "No new migrations in this PR"
+            exit 0
+          fi
+
+          echo "New migrations detected:"
+          echo "$NEW_MIGRATIONS"
+
+          MAIN_SNAPSHOT=$(git show origin/main:src/backend/Shadowbrook.Api/Migrations/ApplicationDbContextModelSnapshot.cs 2>/dev/null || true)
+          MAIN_HEAD=$(echo "$MAIN_SNAPSHOT" | grep -oP '(?<=\[Migration\(")[^"]+' | tail -1 || true)
+          echo "Main migration head: ${MAIN_HEAD:-none}"
+
+          for migration in $NEW_MIGRATIONS; do
+            designer="${migration%.cs}.Designer.cs"
+            if [ -f "$designer" ]; then
+              PREDECESSOR=$(grep -oP '(?<=migrationId: ")[^"]+' "$designer" | head -1 || true)
+              echo "Migration predecessor in Designer.cs: ${PREDECESSOR:-none}"
+              if [ -n "$MAIN_HEAD" ] && [ -n "$PREDECESSOR" ] && [ "$PREDECESSOR" != "$MAIN_HEAD" ]; then
+                echo ""
+                echo "::error file=$designer::Stale migration predecessor."
+                echo "::error::This migration was generated before '$MAIN_HEAD' merged to main."
+                echo "::error::Fix: git rebase origin/main, delete your migration files, then re-run dotnet ef migrations add"
+                exit 1
+              fi
+            fi
+          done
+
+      - name: Unit Tests
+        run: dotnet test shadowbrook.slnx --no-build --filter "Category!=Integration" --logger trx --results-directory TestResults
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: unit-test-results
+          path: TestResults/
+          retention-days: 7
+
+  # ============================================================
+  # CI — API: Integration Tests (only after unit tests pass)
+  # ============================================================
+  integration-test-api:
+    name: Integration Test API
+    needs: [detect-changes, unit-test-api]
     if: needs.detect-changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -70,14 +175,14 @@ jobs:
       - name: Build
         run: dotnet build shadowbrook.slnx --no-restore
 
-      - name: Test
-        run: dotnet test shadowbrook.slnx --no-build --logger trx --results-directory TestResults
+      - name: Integration Tests
+        run: dotnet test shadowbrook.slnx --no-build --filter "Category=Integration" --logger trx --results-directory TestResults
 
       - name: Upload test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: test-results
+          name: integration-test-results
           path: TestResults/
           retention-days: 7
 
@@ -116,11 +221,12 @@ jobs:
   # Deploy API to dev (after CI passes)
   # ============================================================
   deploy-api:
-    needs: [detect-changes, build-api]
+    needs: [detect-changes, unit-test-api, integration-test-api]
     if: |
       !cancelled() &&
       needs.detect-changes.outputs.api == 'true' &&
-      needs.build-api.result == 'success'
+      needs.unit-test-api.result == 'success' &&
+      needs.integration-test-api.result == 'success'
     uses: ./.github/workflows/deploy-api.yml
     with:
       environment: dev


### PR DESCRIPTION
## Summary

- **Simplified statuses:** 12 → 5 (Needs Story, Ready, Implementing, Awaiting Owner, Done). CI/review states tracked by PR mechanics, not board fields.
- **Removed owner review gates:** Pipeline flows autonomously from Needs Story → Ready. Awaiting Owner only triggers for genuine blocks (BA open questions, CI escalation).
- **Sprint branch model:** Issue PRs merge to `sprint/iteration-{N}`, owner reviews the sprint PR to main.
- **Architect two-mode split:** Lightweight feasibility check during planning, detailed implementation plan during sprint execution.
- **BA scope control:** Smallest interpretation, flag gaps don't fill them, no "while we're at it" additions.
- **Status/ID reconciliation:** CLAUDE.md, SKILL.md, and github-project skill all consistent.
- **New github-project skill:** Extracted project management commands and field IDs into a dedicated skill.
- **PR workflow:** Added EF Core migration validation checks.

## Test plan

- [ ] Verify no references to removed statuses (Story Review, Needs Architecture, Architecture Review, CI Pending, In Review, Changes Requested, Ready to Merge) remain in `.claude/`
- [ ] Review agent instructions for consistency with new flow
- [ ] Confirm github-project skill field IDs match CLAUDE.md

Generated with [Claude Code](https://claude.com/claude-code)