### PR TITLE
fix: enable Serilog to forward logs to OTel provider

### DIFF
--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -45,7 +45,8 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .Enrich.WithEnvironmentName()
     .Enrich.With(services.GetRequiredService<TenantIdEnricher>())
     .WriteTo.Console(outputTemplate:
-        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"));
+        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"),
+    writeToProviders: true);
 
 builder.Services.AddSingleton<TenantIdEnricher>();
 


### PR DESCRIPTION
## Summary
- Add `writeToProviders: true` to `UseSerilog()` so structured logs (with TenantId enrichment) flow through the OTel pipeline to App Insights
- Without this, `UseSerilog()` replaces the default logging pipeline and logs never reach the OTel `ILoggerProvider` — resulting in zero traces in App Insights despite requests/dependencies working fine

## Test plan
- [ ] Deploy to test environment
- [ ] Query App Insights: `traces | where timestamp > ago(15m) | take 10` — should now return Serilog logs
- [ ] Verify `TenantId` appears in `customDimensions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)