### PR TITLE
refactor: simplify waitlist position to active entry count

### DIFF
--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Endpoints/WalkUpJoinEndpoints.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Endpoints/WalkUpJoinEndpoints.cs
@@ -109,27 +109,18 @@ public static class WalkUpJoinEndpoints
             .Select(c => c.TimeZoneId)
             .FirstAsync();
 
+        var activeCount = await db.GolferWaitlistEntries
+            .CountAsync(e => e.CourseWaitlistId == waitlist.Id && e.RemovedAt == null);
+
         var entry = await waitlist.Join(golfer, entryRepo, timeProvider, courseTimeZoneId);
         entryRepo.Add(entry);
-
-        // Intentional mid-flow save: position query reads from DB,
-        // so the new entry must be flushed first. This mirrors the golfer
-        // upsert pattern above. Wolverine won't double-save a clean tracker.
-        await db.SaveChangesAsync();
-
-        var joinedAt = entry.JoinedAt;
-        var activeEntries = await db.GolferWaitlistEntries
-            .Where(e => e.CourseWaitlistId == waitlist.Id && e.RemovedAt == null)
-            .Select(e => e.JoinedAt)
-            .ToListAsync();
-        var position = activeEntries.Count(t => t <= joinedAt);
 
         var submittedName = $"{request.FirstName.Trim()} {request.LastName.Trim()}";
 
         return Results.Created($"/walkup/join", new JoinWaitlistResponse(
             entry.Id,
             submittedName,
-            position,
+            activeCount + 1,
             courseName));
     }
 }

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Endpoints/WalkUpWaitlistEndpoints.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Endpoints/WalkUpWaitlistEndpoints.cs
@@ -248,18 +248,6 @@ public static class WalkUpWaitlistEndpoints
         var entry = await waitlist.Join(golfer, entryRepo, timeProvider, timeZoneId, request.GroupSize ?? 1);
         entryRepo.Add(entry);
 
-        // Intentional mid-flow save: position query reads from DB,
-        // so the new entry must be flushed first. This mirrors the golfer
-        // upsert pattern above. Wolverine won't double-save a clean tracker.
-        await db.SaveChangesAsync();
-
-        var joinedAt = entry.JoinedAt;
-        var activeEntries = await db.GolferWaitlistEntries
-            .Where(e => e.CourseWaitlistId == waitlist.Id && e.RemovedAt == null)
-            .Select(e => e.JoinedAt)
-            .ToListAsync();
-        var position = activeEntries.Count(t => t <= joinedAt);
-
         var submittedName = $"{request.FirstName.Trim()} {request.LastName.Trim()}";
 
         return Results.Created(
@@ -269,7 +257,6 @@ public static class WalkUpWaitlistEndpoints
                 submittedName,
                 golfer.Phone,
                 entry.GroupSize,
-                position,
                 courseName));
     }
 
@@ -303,7 +290,6 @@ public record AddGolferToWaitlistResponse(
     string GolferName,
     string GolferPhone,
     int GroupSize,
-    int Position,
     string CourseName);
 
 public record CreateTeeTimeOpeningRequest(string TeeTime, int SlotsAvailable);

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/GolferJoinedWaitlist/SmsHandler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/GolferJoinedWaitlist/SmsHandler.cs
@@ -3,7 +3,6 @@ using Shadowbrook.Api.Infrastructure.Data;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.CourseWaitlistAggregate.Events;
 using Shadowbrook.Domain.GolferAggregate;
-using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 
 namespace Shadowbrook.Api.Features.Waitlist.Handlers;
 
@@ -13,12 +12,10 @@ public static class GolferJoinedWaitlistSmsHandler
         GolferJoinedWaitlist domainEvent,
         ITextMessageService textMessageService,
         IGolferRepository golferRepository,
-        IGolferWaitlistEntryRepository entryRepository,
         ApplicationDbContext db,
         CancellationToken ct)
     {
-        var entry = await entryRepository.GetRequiredByIdAsync(domainEvent.GolferWaitlistEntryId);
-        var golfer = await golferRepository.GetRequiredByIdAsync(entry.GolferId);
+        var golfer = await golferRepository.GetRequiredByIdAsync(domainEvent.GolferId);
 
         var courseName = await db.CourseWaitlists
             .IgnoreQueryFilters()
@@ -27,16 +24,7 @@ public static class GolferJoinedWaitlistSmsHandler
             .FirstOrDefaultAsync(ct)
             ?? throw new InvalidOperationException($"CourseWaitlist {domainEvent.CourseWaitlistId} or its course not found for event {nameof(GolferJoinedWaitlist)}.");
 
-        // Calculate position: count active entries that joined at or before this entry.
-        var joinedAtValues = await db.GolferWaitlistEntries
-            .IgnoreQueryFilters()
-            .Where(e => e.CourseWaitlistId == domainEvent.CourseWaitlistId && e.RemovedAt == null)
-            .Select(e => new { e.Id, e.JoinedAt })
-            .ToListAsync(ct);
-
-        var position = joinedAtValues.Count(e => e.JoinedAt <= entry.JoinedAt);
-
-        var message = $"You're #{position} on the waitlist at {courseName}. Keep your phone handy - we'll text you when a spot opens up!";
+        var message = $"You're on the waitlist at {courseName}. Keep your phone handy - we'll text you when a spot opens up!";
         await textMessageService.SendAsync(golfer.Phone, message, ct);
     }
 }

--- a/src/web/src/features/walkup/__tests__/Confirmation.test.tsx
+++ b/src/web/src/features/walkup/__tests__/Confirmation.test.tsx
@@ -17,10 +17,17 @@ describe('Confirmation', () => {
     expect(screen.getByText("You're on the list, John!")).toBeInTheDocument();
   });
 
-  it('shows position number', () => {
+  it('shows position number when position > 0', () => {
     render(<Confirmation result={result} />);
 
     expect(screen.getByText(/#3 in line at/)).toBeInTheDocument();
+  });
+
+  it('shows only course name when position is 0', () => {
+    render(<Confirmation result={{ ...result, position: 0 }} />);
+
+    expect(screen.getByText('Pine Valley Golf Club')).toBeInTheDocument();
+    expect(screen.queryByText(/#\d+ in line/)).not.toBeInTheDocument();
   });
 
   it('shows course name', () => {

--- a/src/web/src/features/walkup/__tests__/JoinForm.test.tsx
+++ b/src/web/src/features/walkup/__tests__/JoinForm.test.tsx
@@ -105,11 +105,10 @@ describe('JoinForm', () => {
     });
   });
 
-  it('treats 409 duplicate as success and calls onJoined with position', async () => {
+  it('treats 409 duplicate as success and calls onJoined', async () => {
     const onJoined = vi.fn();
     const error = Object.assign(new Error("You're already on the waitlist."), {
       status: 409,
-      data: { error: "You're already on the waitlist.", position: 2 },
     });
 
     mockUseJoinWaitlist.mockReturnValue({
@@ -129,7 +128,7 @@ describe('JoinForm', () => {
 
     await waitFor(() => {
       expect(onJoined).toHaveBeenCalledWith(
-        expect.objectContaining({ position: 2, courseName: 'Pine Valley Golf Club' }),
+        expect.objectContaining({ position: 0, courseName: 'Pine Valley Golf Club' }),
       );
     });
   });

--- a/src/web/src/features/walkup/components/Confirmation.tsx
+++ b/src/web/src/features/walkup/components/Confirmation.tsx
@@ -30,7 +30,9 @@ export default function Confirmation({ result }: ConfirmationProps) {
       <div className="space-y-2">
         <h2 className="text-2xl font-bold">You're on the list, {firstName}!</h2>
         <p className="text-lg text-muted-foreground">
-          #{result.position} in line at {result.courseName}
+          {result.position > 0
+            ? `#${result.position} in line at ${result.courseName}`
+            : result.courseName}
         </p>
       </div>
 

--- a/src/web/src/features/walkup/components/JoinForm.tsx
+++ b/src/web/src/features/walkup/components/JoinForm.tsx
@@ -12,7 +12,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { useJoinWaitlist } from '../hooks/useWalkupJoin';
-import type { VerifyCodeResponse, JoinWaitlistResponse, DuplicateEntryError } from '@/types/waitlist';
+import type { VerifyCodeResponse, JoinWaitlistResponse } from '@/types/waitlist';
 
 const joinSchema = z.object({
   firstName: z.string().min(1, 'First name is required'),
@@ -52,14 +52,13 @@ export default function JoinForm({ verifyData, onJoined }: JoinFormProps) {
           onJoined(result);
         },
         onError: (error) => {
-          const err = error as Error & { status?: number; data?: DuplicateEntryError };
-          // 409 duplicate: treat as success using position from error body
+          const err = error as Error & { status?: number };
+          // 409 duplicate: treat as success — golfer is already on the list
           if (err.status === 409) {
-            const position = err.data?.position ?? 1;
             onJoined({
               entryId: '',
               golferName: `${data.firstName} ${data.lastName}`,
-              position,
+              position: 0,
               courseName: verifyData.courseName,
             });
           }

--- a/src/web/src/types/waitlist.ts
+++ b/src/web/src/types/waitlist.ts
@@ -28,7 +28,6 @@ export interface AddGolferToWaitlistResponse {
   golferName: string;
   golferPhone: string;
   groupSize: number;
-  position: number;
   courseName: string;
 }
 
@@ -82,7 +81,6 @@ export interface JoinWaitlistResponse {
 
 export interface DuplicateEntryError {
   error: string;
-  position: number;
 }
 
 // Walk-up offer (golfer claim flow)

--- a/tests/Shadowbrook.Api.Tests/RemoveWaitlistEntryTests.cs
+++ b/tests/Shadowbrook.Api.Tests/RemoveWaitlistEntryTests.cs
@@ -200,7 +200,6 @@ public class RemoveWaitlistEntryTests(TestWebApplicationFactory factory) : IAsyn
         string GolferName,
         string GolferPhone,
         int GroupSize,
-        int Position,
         string CourseName);
 
     private record WalkUpWaitlistTodayResponse(

--- a/tests/Shadowbrook.Api.Tests/WalkUpJoinEndpointsTests.cs
+++ b/tests/Shadowbrook.Api.Tests/WalkUpJoinEndpointsTests.cs
@@ -432,7 +432,7 @@ public class WalkUpJoinEndpointsTests(TestWebApplicationFactory factory) : IAsyn
 
     private record VerifyCodeResponse(Guid CourseWaitlistId, string CourseName, string ShortCode);
     private record JoinWaitlistResponse(Guid EntryId, string GolferName, int Position, string CourseName);
-    private record DuplicateEntryError(string Error, int Position);
+    private record DuplicateEntryError(string Error);
     private record ErrorResponse(string Error);
     private record CourseIdResponse(Guid Id);
     private record TenantIdResponse(Guid Id);

--- a/tests/Shadowbrook.Api.Tests/WalkUpWaitlistEndpointsTests.cs
+++ b/tests/Shadowbrook.Api.Tests/WalkUpWaitlistEndpointsTests.cs
@@ -253,7 +253,6 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
         var body = await response.Content.ReadFromJsonAsync<AddGolferToWaitlistResponse>();
         Assert.NotNull(body);
         Assert.Equal("Bob B", body!.GolferName);
-        Assert.Equal(2, body.Position);
     }
 
     // -------------------------------------------------------------------------
@@ -368,7 +367,6 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
         Assert.Equal("Jane Smith", body.GolferName);
         Assert.Equal("+15558675309", body.GolferPhone);
         Assert.Equal(2, body.GroupSize);
-        Assert.Equal(1, body.Position);
         Assert.False(string.IsNullOrEmpty(body.CourseName));
     }
 
@@ -455,29 +453,6 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
         var body = await response.Content.ReadFromJsonAsync<AddGolferToWaitlistResponse>();
         Assert.NotNull(body);
         Assert.Equal(1, body!.GroupSize);
-    }
-
-    [Fact]
-    public async Task AddGolfer_MultipleGolfers_CorrectPositions()
-    {
-        var (_, courseId) = await CreateTestCourseAsync();
-        await PostOpenAsync(courseId);
-
-        var r1 = await PostAddGolferAsync(courseId, new { FirstName = "Alice", LastName = "A", Phone = "555-111-0001" });
-        var r2 = await PostAddGolferAsync(courseId, new { FirstName = "Bob", LastName = "B", Phone = "555-111-0002" });
-        var r3 = await PostAddGolferAsync(courseId, new { FirstName = "Carol", LastName = "C", Phone = "555-111-0003" });
-
-        var b1 = await r1.Content.ReadFromJsonAsync<AddGolferToWaitlistResponse>();
-        var b2 = await r2.Content.ReadFromJsonAsync<AddGolferToWaitlistResponse>();
-        var b3 = await r3.Content.ReadFromJsonAsync<AddGolferToWaitlistResponse>();
-
-        Assert.Equal(HttpStatusCode.Created, r1.StatusCode);
-        Assert.Equal(HttpStatusCode.Created, r2.StatusCode);
-        Assert.Equal(HttpStatusCode.Created, r3.StatusCode);
-
-        Assert.Equal(1, b1!.Position);
-        Assert.Equal(2, b2!.Position);
-        Assert.Equal(3, b3!.Position);
     }
 
     [Fact]
@@ -606,10 +581,8 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
         string GolferName,
         string GolferPhone,
         int GroupSize,
-        int Position,
         string CourseName);
 
-    private record ConflictResponse(string Error, int Position);
     private record ErrorResponse(string Error);
     private record CourseIdResponse(Guid Id);
     private record TenantIdResponse(Guid Id);


### PR DESCRIPTION
## Summary
- Replaced duplicated JoinedAt-based position calculation with a simple `COUNT` of active entries, returned only on the golfer-facing `/walkup/join` endpoint
- Removed position from the operator add-golfer response (`/entries`), SMS confirmation message, and 409 duplicate error body
- Removed mid-endpoint `SaveChangesAsync()` calls that were only needed for the old position query
- SMS handler now reads `GolferId` directly from the domain event instead of loading the entry first

## Test plan
- [x] All 254 backend tests pass (1 removed: `AddGolfer_MultipleGolfers_CorrectPositions` — no longer applicable)
- [x] All 174 frontend unit tests pass
- [x] Build and lint clean
- [ ] Verify golfer-facing join flow shows position number on confirmation screen
- [ ] Verify 409 duplicate join shows confirmation without position number

### Test assertion changes
- Removed position assertions from operator endpoint tests (field removed from response)
- Removed `AddGolfer_MultipleGolfers_CorrectPositions` test (position no longer in operator response)
- Updated 409 duplicate test to expect `position: 0` instead of position from error body

🤖 Generated with [Claude Code](https://claude.com/claude-code)