### PR TITLE
fix: remove synchronize trigger from owner gate to prevent race condition

### DIFF
--- a/.github/workflows/owner-gate.yml
+++ b/.github/workflows/owner-gate.yml
@@ -7,7 +7,7 @@ name: Owner Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary
- Removes `synchronize` trigger from the Owner Gate workflow, keeping `opened`, `reopened`, `labeled`, `unlabeled`, and `pull_request_review`
- Fixes a race condition where a push and approval in quick succession causes the push-triggered run to fail (no approval yet), blocking the PR even though the review-triggered run passes

## Test plan
- [ ] Verify owner gate still runs on PR creation
- [ ] Verify owner gate runs on approval review
- [ ] Verify pushing new commits no longer triggers a failing owner gate check

Closes #272 race condition observed at https://github.com/benjamingolfco/shadowbrook/pull/272#pullrequestreview-4023009759

🤖 Generated with [Claude Code](https://claude.com/claude-code)