### PR TITLE
fix: update E2E offer confirmation fixture

### DIFF
--- a/src/web/e2e/fixtures/walk-up-offer-page.ts
+++ b/src/web/e2e/fixtures/walk-up-offer-page.ts
@@ -20,6 +20,6 @@ export class WalkUpOfferPage {
   }
 
   async expectConfirmation() {
-    await expect(this.page.getByText('Request Received')).toBeVisible();
+    await expect(this.page.getByText('Tee Time Claimed')).toBeVisible();
   }
 }


### PR DESCRIPTION
## Summary
- Fix E2E fixture expecting 'Request Received' instead of 'Tee Time Claimed'
- Broken since #282 changed the heading text without updating the E2E fixture

## Test plan
- [x] E2E fixture updated to match current UI text

🤖 Generated with [Claude Code](https://claude.com/claude-code)