### PR TITLE
chore: set container app minReplicas to 1

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -161,7 +161,7 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: 1
         maxReplicas: 1
         rules: [
           {


### PR DESCRIPTION
## Summary
- Sets `minReplicas` from 0 to 1 in the container app Bicep module to prevent cold starts

## Test plan
- [ ] Verify Bicep template validates (`az bicep build`)
- [ ] Confirm container app maintains at least 1 replica after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>