### PR TITLE
fix: clean up duplicate data before unique index migration

### DIFF
--- a/src/backend/Shadowbrook.Api/Migrations/20260330155927_AddTeeTimeOpeningActiveUniqueIndex.cs
+++ b/src/backend/Shadowbrook.Api/Migrations/20260330155927_AddTeeTimeOpeningActiveUniqueIndex.cs
@@ -8,11 +8,30 @@ namespace Shadowbrook.Api.Migrations;
 public partial class AddTeeTimeOpeningActiveUniqueIndex : Migration
 {
     /// <inheritdoc />
-    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.Sql("""
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Cancel duplicate Open tee time openings before adding the unique index.
+        // Keeps the most recently created row (highest Id) and sets older duplicates to Cancelled.
+        migrationBuilder.Sql("""
+            WITH Duplicates AS (
+                SELECT Id,
+                       ROW_NUMBER() OVER (PARTITION BY CourseId, TeeTime ORDER BY Id DESC) AS RowNum
+                FROM [TeeTimeOpenings]
+                WHERE [Status] = 'Open'
+            )
+            UPDATE t
+            SET t.[Status] = 'Cancelled', t.[CancelledAt] = SYSUTCDATETIME()
+            FROM [TeeTimeOpenings] t
+            INNER JOIN Duplicates d ON t.Id = d.Id
+            WHERE d.RowNum > 1;
+            """);
+
+        migrationBuilder.Sql("""
             CREATE UNIQUE NONCLUSTERED INDEX [IX_TeeTimeOpenings_CourseId_TeeTime_ActiveUnique]
             ON [TeeTimeOpenings] ([CourseId], [TeeTime])
             WHERE [Status] = 'Open';
             """);
+    }
 
     /// <inheritdoc />
     protected override void Down(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Summary
- The `AddTeeTimeOpeningActiveUniqueIndex` migration was crash-looping the test Container App (997+ restarts) because existing data had duplicate `(CourseId, TeeTime)` rows with `Status='Open'`
- Adds a data cleanup step that cancels older duplicate Open tee time openings before creating the filtered unique index
- The old revision was still serving traffic, masking the failure from the deploy health check

## Test plan
- [x] `dotnet build` passes
- [ ] PR CI passes (migration validation + tests)
- [ ] After merge, verify the new test Container App revision starts successfully

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)