### PR TITLE
fix: E2E strict mode violation on tee time opening assertion

### DIFF
--- a/.claude/rules/frontend/react-conventions.md
+++ b/.claude/rules/frontend/react-conventions.md
@@ -118,3 +118,42 @@ Vitest + React Testing Library.
 - Hooks are named exports in `features/{feature}/hooks/`
 - Loading/error/empty states are handled in the page component, not the hook
 - Use shadcn `Table` for tabular data, `Form` for forms, `Button` for actions
+
+## E2E Test Locators
+
+Playwright E2E tests live in `e2e/` with page object fixtures in `e2e/fixtures/`.
+
+### Locator Priority
+
+1. **Semantic roles/labels** (`getByRole`, `getByLabel`) — preferred for interactive elements (buttons, inputs, headings, dialogs)
+2. **`data-testid`** — for non-semantic elements, structural containers, or dual-render disambiguation
+3. **Text matchers** (`getByText`) — only for asserting dynamic content appeared, never for interaction targets
+4. **Never use** CSS class selectors, XPath, or `page.locator('text=...')`
+
+### When to add `data-testid`
+
+- Element has no accessible role (status displays, code readouts, statistics)
+- Same content renders in both mobile and desktop layouts (dual-render pattern)
+- Need to scope child queries within a container
+- Do NOT add `data-testid` to buttons, form fields, or headings — use roles/labels instead
+
+### `data-testid` naming
+
+- Kebab-case, lowercase: `short-code`, `opening-status`, `opening-row-desktop`
+- No element type encoding: `short-code` not `short-code-span`
+- Feature prefix only when shared across pages
+- Dynamic items use ID suffix: `data-testid={`opening-row-${id}`}`
+- Test IDs live on the component that renders the element, not passed as props
+
+### Dual-render (mobile/desktop) pattern
+
+Components that render both mobile and desktop layouts (via `md:hidden` / `hidden md:flex`) must place `data-testid` on **both variants** with a `-mobile` / `-desktop` suffix. E2E tests scope to the desktop variant since Playwright runs at 1280x720 (above the 768px `md:` breakpoint). Example:
+
+```tsx
+<div className="md:hidden" data-testid="opening-row-mobile">...</div>
+<div className="hidden md:flex" data-testid="opening-row-desktop">...</div>
+```
+
+### Page object pattern
+
+All E2E locators live in page object fixtures (`e2e/fixtures/`), never as raw locators in spec files. Specs should read like user stories; fixtures encapsulate the how.

--- a/src/web/e2e/fixtures/operator-waitlist-page.ts
+++ b/src/web/e2e/fixtures/operator-waitlist-page.ts
@@ -27,8 +27,8 @@ export class OperatorWaitlistPage {
 
     // No confirmation dialog — button directly fires the mutation.
     // Wait for either the short code (success) or an error message (API failure).
-    const shortCode = this.page.locator('span.font-mono.font-bold');
-    const error = this.page.locator('text=/Error/i');
+    const shortCode = this.page.getByTestId('short-code');
+    const error = this.page.getByRole('alert');
 
     const result = await Promise.race([
       shortCode.waitFor().then(() => 'success' as const),
@@ -42,9 +42,15 @@ export class OperatorWaitlistPage {
   }
 
   async getShortCode(): Promise<string> {
-    const codeElement = this.page.locator('span.font-mono.font-bold');
+    const codeElement = this.page.getByTestId('short-code');
     const spacedCode = await codeElement.textContent();
     return spacedCode?.replace(/\s/g, '') ?? '';
+  }
+
+  async verifyOpeningPosted() {
+    // Scope to the desktop layout row — at 1280px the desktop layout is visible.
+    const desktopRow = this.page.locator('[data-testid="opening-row-desktop"]');
+    await desktopRow.getByText('Waiting for golfers...').waitFor();
   }
 
   async addTeeTimeOpening(time: string, slots: number) {

--- a/src/web/e2e/fixtures/walk-up-offer-page.ts
+++ b/src/web/e2e/fixtures/walk-up-offer-page.ts
@@ -16,6 +16,7 @@ export class WalkUpOfferPage {
     await this.page.getByRole('button', { name: 'Claim This Tee Time' }).click();
 
     const dialog = this.page.getByRole('alertdialog');
+    await dialog.waitFor();
     await dialog.getByRole('button', { name: 'Confirm' }).click();
   }
 

--- a/src/web/e2e/tests/walkup/walkup-flow.spec.ts
+++ b/src/web/e2e/tests/walkup/walkup-flow.spec.ts
@@ -65,9 +65,8 @@ test.describe.serial('Walkup Waitlist Flow', () => {
     const timeStr = `${String(futureTime.getHours()).padStart(2, '0')}:${String(futureTime.getMinutes()).padStart(2, '0')}`;
     await waitlist.addTeeTimeOpening(timeStr, 1);
 
-    // Verify it appears in the openings list
-    await waitlist.selectOpeningsTab();
-    await expect(page.getByText('Open', { exact: true })).toBeVisible();
+    // Verify the opening appears in the list
+    await waitlist.verifyOpeningPosted();
   });
 
   test('golfer receives offer via SMS', async () => {

--- a/src/web/src/features/operator/components/OpeningsList.tsx
+++ b/src/web/src/features/operator/components/OpeningsList.tsx
@@ -74,7 +74,7 @@ export function OpeningsList({ openings, onCancel, cancellingId }: OpeningsListP
                 ${opening.status === 'Filled' ? 'border-l-3 border-l-success' : ''}`}
             >
               {/* Mobile layout — stacked rows, hidden at md+ */}
-              <div className="md:hidden space-y-0.5">
+              <div className="md:hidden space-y-0.5" data-testid="opening-row-mobile">
                 <div className="flex items-center justify-between">
                   <span className="text-base font-semibold">
                     {formatWallClockTime(opening.teeTime)}
@@ -109,7 +109,7 @@ export function OpeningsList({ openings, onCancel, cancellingId }: OpeningsListP
               </div>
 
               {/* Desktop layout — single flex row, hidden below md */}
-              <div className="hidden md:flex md:items-center md:gap-4">
+              <div className="hidden md:flex md:items-center md:gap-4" data-testid="opening-row-desktop">
                 <span className="text-base font-semibold w-[80px] shrink-0">
                   {formatWallClockTime(opening.teeTime)}
                 </span>

--- a/src/web/src/features/operator/pages/WalkUpWaitlist.tsx
+++ b/src/web/src/features/operator/pages/WalkUpWaitlist.tsx
@@ -185,7 +185,7 @@ export default function WalkUpWaitlist() {
             </p>
           )}
           {openMutation.isError && !is409 && (
-            <p className="text-sm text-destructive">
+            <p className="text-sm text-destructive" role="alert">
               Couldn't open waitlist. Try again.
             </p>
           )}
@@ -249,7 +249,7 @@ export default function WalkUpWaitlist() {
           </h1>
           <Badge variant="success">Open</Badge>
           <span className="inline-flex items-center gap-1 whitespace-nowrap">
-            <span className="font-mono font-bold text-base md:text-lg tracking-[0.15em] md:tracking-[0.25em]">
+            <span data-testid="short-code" className="font-mono font-bold text-base md:text-lg tracking-[0.15em] md:tracking-[0.25em]">
               {waitlist.shortCode.split('').join(' ')}
             </span>
             <button


### PR DESCRIPTION
## Summary
- Replace fragile CSS class selectors (`span.font-mono.font-bold`) and text matchers (`getByText('Open')`) with `data-testid` attributes and ARIA roles
- Add `data-testid="short-code"` to the short code display in WalkUpWaitlist
- Add `data-testid="opening-row-mobile"` / `opening-row-desktop"` to dual-render layouts in OpeningsList
- Add `role="alert"` to error messages for semantic error detection
- Update all E2E fixtures to use `getByTestId` and `getByRole('alert')` instead of CSS/text locators
- Add `dialog.waitFor()` in walk-up offer fixture to prevent race condition
- Add E2E locator conventions to `.claude/rules/frontend/react-conventions.md`

## Test plan
- [x] All 250 unit tests passing
- [x] Lint clean
- [ ] E2E tests pass in CI against test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)