### PR TITLE
chore: gitignore .superpowers/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 # Worktrees
 .worktrees/
 
+# Superpowers scratch state
+.superpowers/
+
 # Env - ignore local overrides, but commit environment-specific configs
 .env.local
 .env.*.local


### PR DESCRIPTION
## Summary
- Adds `.superpowers/` to `.gitignore` — brainstorm scratch state that shouldn't be committed

## Test plan
- [x] Verify `.superpowers/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)