### PR TITLE
chore: process @cleanup comments across waitlist feature

### DIFF
--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Reviewer Memory Index
+
+- [feedback_non_agentic_review_style.md](feedback_non_agentic_review_style.md) — Non-agentic PR reviews: use `--comment` only, never block

--- a/.claude/agent-memory/reviewer/feedback_non_agentic_review_style.md
+++ b/.claude/agent-memory/reviewer/feedback_non_agentic_review_style.md
@@ -1,0 +1,11 @@
+---
+name: Non-agentic PR review style
+description: For non-agentic (human-authored) PRs, always use gh pr review --comment, never --request-changes
+type: feedback
+---
+
+Non-agentic PRs (human-authored, manual commits) are reviewed with `gh pr review --comment` only — feedback without blocking. Reserve `--request-changes` for agentic PRs where the agent can respond and iterate.
+
+**Why:** The code-review skill explicitly distinguishes between agentic and non-agentic modes. Blocking a human author's PR with `--request-changes` is the wrong tool when the intent is advisory feedback.
+
+**How to apply:** Check how the review was invoked. If the prompt says "non-agentic" or the PR is clearly human-authored without pipeline context, use `--comment` regardless of findings.

--- a/.claude/rules/backend/backend-conventions.md
+++ b/.claude/rules/backend/backend-conventions.md
@@ -97,6 +97,32 @@ Shadowbrook.Api/
 - Validators live in the same file as their request record DTOs (inline pattern), or in a separate file if complex
 - Endpoints can trust that the request body is valid — no need for manual validation of fields that have validator rules
 
+## Configuration (IOptions Pattern)
+
+- Always use strongly-typed options classes — never read `IConfiguration["key"]` directly in application code
+- Options classes live in `Infrastructure/Configuration/`
+- Register with `builder.Services.Configure<T>(builder.Configuration.GetSection("SectionName"))` near the top of service registrations in `Program.cs`
+- Inject `IOptions<T>` (singleton-lifetime config) — not `IOptionsSnapshot` or `IOptionsMonitor` unless reload-on-change is explicitly needed
+- Access the value via the `.Value` property
+- Keep options classes simple POCOs with `{ get; init; }` properties and sensible defaults
+
+```csharp
+// Infrastructure/Configuration/AppSettings.cs
+public class AppSettings
+{
+    public string FrontendUrl { get; init; } = string.Empty;
+}
+
+// Program.cs
+builder.Services.Configure<AppSettings>(builder.Configuration.GetSection("App"));
+
+// Handler
+public static async Task Handle(IOptions<AppSettings> appSettings, ...)
+{
+    var baseUrl = appSettings.Value.FrontendUrl;
+}
+```
+
 ## Identifiers
 
 - Use `Guid.CreateVersion7()` when generating new GUIDs for database identifiers — it produces time-ordered UUIDs (UUIDv7) that sort chronologically, avoiding index fragmentation in SQL Server

--- a/.claude/rules/backend/backend-conventions.md
+++ b/.claude/rules/backend/backend-conventions.md
@@ -148,6 +148,18 @@ The project uses [WolverineFx](https://wolverinefx.net) for message handling. Se
 - Handlers that need to publish follow-on events inject `IMessageBus` and call `bus.PublishAsync()`
 - `MultipleHandlerBehavior.Separated` — multiple handlers for the same event type run independently
 
+### Command Colocation
+
+Command and message records MUST be defined in the same file as their handler. This keeps the
+message contract and its processing logic together — if you're reading a handler, you can see
+exactly what shape of message it expects without navigating elsewhere.
+
+- Commands handled by a standalone handler class → define the record in the handler file
+- Timeout messages consumed by a policy → define the record in the policy file
+- Wake-up/trigger commands consumed by a policy → define the record in the policy file
+
+The rule is: **the record lives with the code that has the `Handle` method for it.**
+
 **No silent returns — hard rule:**
 - Every early return in a handler MUST either throw or log a warning before returning. Silent failures in event handlers are invisible in production.
 - **ID lookups throw:** When looking up an entity by an ID from an event/command, use `GetRequiredByIdAsync(id)` — it throws `EntityNotFoundException` if not found. Extension methods for all repositories are in `Shadowbrook.Domain.Common.RepositoryExtensions`. Never write `GetByIdAsync(...) ?? throw` inline — always use `GetRequiredByIdAsync`.

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/ExpireTeeTimeOpening/Handler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/ExpireTeeTimeOpening/Handler.cs
@@ -1,8 +1,9 @@
-using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 
 namespace Shadowbrook.Api.Features.Waitlist.Handlers;
+
+public record ExpireTeeTimeOpening(Guid OpeningId);
 
 public static class ExpireTeeTimeOpeningHandler
 {

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/FindAndOfferEligibleGolfers/Handler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/FindAndOfferEligibleGolfers/Handler.cs
@@ -22,10 +22,15 @@ public static class FindAndOfferEligibleGolfersHandler
     {
         var opening = await openingRepository.GetRequiredByIdAsync(command.OpeningId);
 
+        if (!opening.IsOpen)
+        {
+            logger.LogWarning("Opening {OpeningId} is not open (status: {Status}), skipping offer matching", command.OpeningId, opening.Status);
+            return;
+        }
+
         var eligibleEntries = await matchingService.FindEligibleEntriesAsync(opening, ct);
 
-        var offersToCreate = Math.Min(eligibleEntries.Count, command.MaxOffers);
-        if (offersToCreate == 0)
+        if (eligibleEntries.Count == 0)
         {
             logger.LogWarning(
                 "No eligible golfers found for opening {OpeningId}, skipping offer dispatch",
@@ -33,9 +38,8 @@ public static class FindAndOfferEligibleGolfersHandler
             return;
         }
 
-        for (var i = 0; i < offersToCreate; i++)
+        foreach (var entry in eligibleEntries.Take(command.MaxOffers))
         {
-            var entry = eligibleEntries[i];
             var offer = entry.CreateOffer(opening, timeProvider);
             offerRepository.Add(offer);
         }

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/GolferJoinedWaitlist/WakeUpOfferPolicyHandler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/GolferJoinedWaitlist/WakeUpOfferPolicyHandler.cs
@@ -1,8 +1,10 @@
-using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Shadowbrook.Api.Features.Waitlist.Policies;
-using Shadowbrook.Api.Infrastructure.Data;
+using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
 using Shadowbrook.Domain.CourseWaitlistAggregate.Events;
-using Shadowbrook.Domain.TeeTimeOpeningAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
+using Shadowbrook.Domain.WaitlistServices;
 
 namespace Shadowbrook.Api.Features.Waitlist.Handlers;
 
@@ -10,27 +12,29 @@ public static class GolferJoinedWaitlistWakeUpHandler
 {
     public static async Task<WakeUpOfferPolicy?> Handle(
         GolferJoinedWaitlist evt,
-        ApplicationDbContext db)
+        ICourseWaitlistRepository waitlistRepository,
+        IGolferWaitlistEntryRepository entryRepository,
+        WaitlistMatchingService matchingService,
+        ILogger logger,
+        CancellationToken ct)
     {
-        // Find the waitlist to get courseId and date
-        var waitlist = await db.CourseWaitlists
-            .IgnoreQueryFilters()
-            .FirstOrDefaultAsync(w => w.Id == evt.CourseWaitlistId)
-            ?? throw new InvalidOperationException($"CourseWaitlist {evt.CourseWaitlistId} not found for event {nameof(GolferJoinedWaitlist)}.");
+        var waitlist = await waitlistRepository.GetRequiredByIdAsync(evt.CourseWaitlistId);
 
-        // Find any active opening for this course/date
-        var dayStart = waitlist.Date.ToDateTime(TimeOnly.MinValue);
-        var dayEnd = waitlist.Date.AddDays(1).ToDateTime(TimeOnly.MinValue);
-        var activeOpening = await db.TeeTimeOpenings
-            .FirstOrDefaultAsync(o => o.CourseId == waitlist.CourseId
-                && o.TeeTime.Value >= dayStart && o.TeeTime.Value < dayEnd
-                && o.Status == TeeTimeOpeningStatus.Open);
+        var entry = await entryRepository.GetByIdAsync(evt.GolferWaitlistEntryId);
+        if (entry is null)
+        {
+            logger.LogWarning(
+                "GolferWaitlistEntry {GolferWaitlistEntryId} not found, skipping WakeUpOfferPolicy",
+                evt.GolferWaitlistEntryId);
+            return null;
+        }
 
-        if (activeOpening is null)
+        var opening = await matchingService.FindOpeningForGolferAsync(entry, waitlist.CourseId, waitlist.Date, ct);
+        if (opening is null)
         {
             return null;
         }
 
-        return new WakeUpOfferPolicy(activeOpening.Id);
+        return new WakeUpOfferPolicy(opening.Id);
     }
 }

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/MarkOfferStale/Handler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/MarkOfferStale/Handler.cs
@@ -1,9 +1,10 @@
 using Microsoft.Extensions.Logging;
-using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.WaitlistOfferAggregate;
 
 namespace Shadowbrook.Api.Features.Waitlist.Handlers;
+
+public record MarkOfferStale(Guid WaitlistOfferId, Guid OpeningId);
 
 public static class MarkOfferStaleHandler
 {

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/WaitlistOfferCreated/SendSmsHandler.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Handlers/WaitlistOfferCreated/SendSmsHandler.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Options;
+using Shadowbrook.Api.Infrastructure.Configuration;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.CourseAggregate;
 using Shadowbrook.Domain.GolferAggregate;
@@ -16,7 +18,7 @@ public static class WaitlistOfferCreatedSendSmsHandler
         IGolferRepository golferRepository,
         ICourseRepository courseRepository,
         ITextMessageService textMessageService,
-        IConfiguration configuration,
+        IOptions<AppSettings> appSettings,
         ITimeProvider timeProvider,
         CancellationToken ct)
     {
@@ -27,7 +29,7 @@ public static class WaitlistOfferCreatedSendSmsHandler
         var course = await courseRepository.GetByIdAsync(opening.CourseId);
         var courseName = course?.Name ?? "Course";
 
-        var baseUrl = configuration["App:FrontendUrl"];
+        var baseUrl = appSettings.Value.FrontendUrl;
         if (string.IsNullOrEmpty(baseUrl))
         {
             throw new InvalidOperationException(

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicy.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicy.cs
@@ -1,3 +1,4 @@
+using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Api.Infrastructure.Services;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
@@ -46,5 +47,3 @@ public class TeeTimeOpeningExpirationPolicy : Saga
 }
 
 public record TeeTimeOpeningExpirationTimeout(Guid Id, TimeSpan Delay) : TimeoutMessage(Delay);
-
-public record ExpireTeeTimeOpening(Guid OpeningId);

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/WaitlistOfferResponsePolicy.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/WaitlistOfferResponsePolicy.cs
@@ -1,4 +1,4 @@
-using Shadowbrook.Domain.WaitlistOfferAggregate;
+using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
 using Wolverine;
 using Wolverine.Persistence.Sagas;
@@ -41,5 +41,3 @@ public class WaitlistOfferResponsePolicy : Saga
 }
 
 public record OfferResponseBufferTimeout(Guid Id, TimeSpan Buffer) : TimeoutMessage(Buffer);
-
-public record MarkOfferStale(Guid WaitlistOfferId, Guid OpeningId);

--- a/src/backend/Shadowbrook.Api/Infrastructure/Configuration/AppSettings.cs
+++ b/src/backend/Shadowbrook.Api/Infrastructure/Configuration/AppSettings.cs
@@ -1,0 +1,6 @@
+namespace Shadowbrook.Api.Infrastructure.Configuration;
+
+public class AppSettings
+{
+    public string FrontendUrl { get; init; } = string.Empty;
+}

--- a/src/backend/Shadowbrook.Api/Infrastructure/Repositories/TeeTimeOpeningRepository.cs
+++ b/src/backend/Shadowbrook.Api/Infrastructure/Repositories/TeeTimeOpeningRepository.cs
@@ -29,6 +29,18 @@ public class TeeTimeOpeningRepository(ApplicationDbContext db) : ITeeTimeOpening
                 && o.TeeTime.Value == teeTime.Value);
     }
 
+    public async Task<List<TeeTimeOpening>> FindActiveOpeningsForCourseDateAsync(
+        Guid courseId, DateOnly date, CancellationToken ct = default)
+    {
+        var dayStart = date.ToDateTime(TimeOnly.MinValue);
+        var dayEnd = date.AddDays(1).ToDateTime(TimeOnly.MinValue);
+        return await db.TeeTimeOpenings
+            .Where(o => o.CourseId == courseId
+                && o.TeeTime.Value >= dayStart && o.TeeTime.Value < dayEnd
+                && o.Status == TeeTimeOpeningStatus.Open)
+            .ToListAsync(ct);
+    }
+
     public void Add(TeeTimeOpening opening) =>
         db.TeeTimeOpenings.Add(opening);
 }

--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -6,6 +6,7 @@ using OpenTelemetry.Trace;
 using Serilog;
 using Shadowbrook.Api.Auth;
 using Shadowbrook.Api.Features.Dev;
+using Shadowbrook.Api.Infrastructure.Configuration;
 using Shadowbrook.Api.Infrastructure.Data;
 using Shadowbrook.Api.Infrastructure.Middleware;
 using Shadowbrook.Api.Infrastructure.Observability;
@@ -62,6 +63,8 @@ if (!string.IsNullOrEmpty(appInsightsConnectionString))
         .WithLogging()
         .UseAzureMonitor(o => o.ConnectionString = appInsightsConnectionString);
 }
+
+builder.Services.Configure<AppSettings>(builder.Configuration.GetSection("App"));
 
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<ApplicationDbContext>();

--- a/src/backend/Shadowbrook.Domain/BookingAggregate/IBookingRepository.cs
+++ b/src/backend/Shadowbrook.Domain/BookingAggregate/IBookingRepository.cs
@@ -2,9 +2,8 @@ using Shadowbrook.Domain.Common;
 
 namespace Shadowbrook.Domain.BookingAggregate;
 
-public interface IBookingRepository
+public interface IBookingRepository : IRepository<Booking>
 {
-    Task<Booking?> GetByIdAsync(Guid id);
     void Add(Booking booking);
     Task<List<Booking>> GetByCourseAndTeeTimeAsync(Guid courseId, TeeTime teeTime, CancellationToken ct = default);
 }

--- a/src/backend/Shadowbrook.Domain/Common/IRepository.cs
+++ b/src/backend/Shadowbrook.Domain/Common/IRepository.cs
@@ -1,0 +1,7 @@
+namespace Shadowbrook.Domain.Common;
+
+public interface IRepository<T>
+    where T : Entity
+{
+    Task<T?> GetByIdAsync(Guid id);
+}

--- a/src/backend/Shadowbrook.Domain/Common/RepositoryExtensions.cs
+++ b/src/backend/Shadowbrook.Domain/Common/RepositoryExtensions.cs
@@ -1,33 +1,8 @@
-using Shadowbrook.Domain.BookingAggregate;
-using Shadowbrook.Domain.CourseAggregate;
-using Shadowbrook.Domain.CourseWaitlistAggregate;
-using Shadowbrook.Domain.GolferAggregate;
-using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
-using Shadowbrook.Domain.TeeTimeOpeningAggregate;
-using Shadowbrook.Domain.WaitlistOfferAggregate;
-
 namespace Shadowbrook.Domain.Common;
 
 public static class RepositoryExtensions
 {
-    public static async Task<Booking> GetRequiredByIdAsync(this IBookingRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(Booking), id);
-
-    public static async Task<Course> GetRequiredByIdAsync(this ICourseRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(Course), id);
-
-    public static async Task<CourseWaitlist> GetRequiredByIdAsync(this ICourseWaitlistRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(CourseWaitlist), id);
-
-    public static async Task<Golfer> GetRequiredByIdAsync(this IGolferRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(Golfer), id);
-
-    public static async Task<GolferWaitlistEntry> GetRequiredByIdAsync(this IGolferWaitlistEntryRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(GolferWaitlistEntry), id);
-
-    public static async Task<TeeTimeOpening> GetRequiredByIdAsync(this ITeeTimeOpeningRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(TeeTimeOpening), id);
-
-    public static async Task<WaitlistOffer> GetRequiredByIdAsync(this IWaitlistOfferRepository repo, Guid id) =>
-        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(nameof(WaitlistOffer), id);
+    public static async Task<T> GetRequiredByIdAsync<T>(this IRepository<T> repo, Guid id)
+        where T : Entity =>
+        await repo.GetByIdAsync(id) ?? throw new EntityNotFoundException(typeof(T).Name, id);
 }

--- a/src/backend/Shadowbrook.Domain/CourseAggregate/ICourseRepository.cs
+++ b/src/backend/Shadowbrook.Domain/CourseAggregate/ICourseRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.CourseAggregate;
 
-public interface ICourseRepository
+public interface ICourseRepository : IRepository<Course>
 {
-    Task<Course?> GetByIdAsync(Guid id);
     Task<List<Course>> GetByTenantIdAsync(Guid tenantId);
     Task<bool> ExistsByNameAsync(Guid tenantId, string name);
     void Add(Course course);

--- a/src/backend/Shadowbrook.Domain/CourseWaitlistAggregate/ICourseWaitlistRepository.cs
+++ b/src/backend/Shadowbrook.Domain/CourseWaitlistAggregate/ICourseWaitlistRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.CourseWaitlistAggregate;
 
-public interface ICourseWaitlistRepository
+public interface ICourseWaitlistRepository : IRepository<CourseWaitlist>
 {
-    Task<CourseWaitlist?> GetByIdAsync(Guid id);
     Task<WalkUpWaitlist?> GetByCourseDateAsync(Guid courseId, DateOnly date);
     Task<WalkUpWaitlist?> GetOpenByCourseDateAsync(Guid courseId, DateOnly date);
     void Add(CourseWaitlist waitlist);

--- a/src/backend/Shadowbrook.Domain/GolferAggregate/IGolferRepository.cs
+++ b/src/backend/Shadowbrook.Domain/GolferAggregate/IGolferRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.GolferAggregate;
 
-public interface IGolferRepository
+public interface IGolferRepository : IRepository<Golfer>
 {
-    Task<Golfer?> GetByIdAsync(Guid id);
     Task<Golfer?> GetByPhoneAsync(string phone);
     void Add(Golfer golfer);
 }

--- a/src/backend/Shadowbrook.Domain/GolferWaitlistEntryAggregate/IGolferWaitlistEntryRepository.cs
+++ b/src/backend/Shadowbrook.Domain/GolferWaitlistEntryAggregate/IGolferWaitlistEntryRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 
-public interface IGolferWaitlistEntryRepository
+public interface IGolferWaitlistEntryRepository : IRepository<GolferWaitlistEntry>
 {
-    Task<GolferWaitlistEntry?> GetByIdAsync(Guid id);
     Task<GolferWaitlistEntry?> GetActiveByWaitlistAndGolferAsync(Guid courseWaitlistId, Guid golferId);
     Task<List<GolferWaitlistEntry>> GetActiveByWaitlistAsync(Guid courseWaitlistId);
     void Add(GolferWaitlistEntry entry);

--- a/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/Exceptions/OpeningNotAvailableException.cs
+++ b/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/Exceptions/OpeningNotAvailableException.cs
@@ -1,6 +1,0 @@
-using Shadowbrook.Domain.Common;
-
-namespace Shadowbrook.Domain.TeeTimeOpeningAggregate.Exceptions;
-
-public class OpeningNotAvailableException(Guid openingId)
-    : DomainException($"Tee time opening {openingId} is not available.");

--- a/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/ITeeTimeOpeningRepository.cs
+++ b/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/ITeeTimeOpeningRepository.cs
@@ -2,9 +2,8 @@ using Shadowbrook.Domain.Common;
 
 namespace Shadowbrook.Domain.TeeTimeOpeningAggregate;
 
-public interface ITeeTimeOpeningRepository
+public interface ITeeTimeOpeningRepository : IRepository<TeeTimeOpening>
 {
-    Task<TeeTimeOpening?> GetByIdAsync(Guid id);
     Task<TeeTimeOpening?> GetActiveByCourseTeeTimeAsync(Guid courseId, TeeTime teeTime);
     Task<TeeTimeOpening?> GetByCourseTeeTimeAsync(Guid courseId, TeeTime teeTime);
     void Add(TeeTimeOpening opening);

--- a/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/ITeeTimeOpeningRepository.cs
+++ b/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/ITeeTimeOpeningRepository.cs
@@ -6,5 +6,6 @@ public interface ITeeTimeOpeningRepository : IRepository<TeeTimeOpening>
 {
     Task<TeeTimeOpening?> GetActiveByCourseTeeTimeAsync(Guid courseId, TeeTime teeTime);
     Task<TeeTimeOpening?> GetByCourseTeeTimeAsync(Guid courseId, TeeTime teeTime);
+    Task<List<TeeTimeOpening>> FindActiveOpeningsForCourseDateAsync(Guid courseId, DateOnly date, CancellationToken ct = default);
     void Add(TeeTimeOpening opening);
 }

--- a/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/TeeTimeOpening.cs
+++ b/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/TeeTimeOpening.cs
@@ -12,6 +12,7 @@ public class TeeTimeOpening : Entity
     public int SlotsRemaining { get; private set; }
     public bool OperatorOwned { get; private set; }
     public TeeTimeOpeningStatus Status { get; private set; }
+    public bool IsOpen => Status == TeeTimeOpeningStatus.Open;
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? FilledAt { get; private set; }
     public DateTimeOffset? ExpiredAt { get; private set; }

--- a/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/TeeTimeOpening.cs
+++ b/src/backend/Shadowbrook.Domain/TeeTimeOpeningAggregate/TeeTimeOpening.cs
@@ -1,4 +1,5 @@
 using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Exceptions;
 
@@ -134,6 +135,12 @@ public class TeeTimeOpening : Entity
             Date = TeeTime.Date,
             TeeTime = TeeTime.Time,
         });
+    }
+
+    public bool IsInGolferWindow(GolferWaitlistEntry entry)
+    {
+        var teeDateTime = TeeTime.Date.ToDateTime(TeeTime.Time);
+        return teeDateTime >= entry.WindowStart && teeDateTime <= entry.WindowEnd;
     }
 
     public void Expire(ITimeProvider timeProvider)

--- a/src/backend/Shadowbrook.Domain/TenantAggregate/ITenantRepository.cs
+++ b/src/backend/Shadowbrook.Domain/TenantAggregate/ITenantRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.TenantAggregate;
 
-public interface ITenantRepository
+public interface ITenantRepository : IRepository<Tenant>
 {
-    Task<Tenant?> GetByIdAsync(Guid id);
     Task<List<Tenant>> GetAllAsync();
     Task<bool> ExistsByNameAsync(string organizationName);
     void Add(Tenant tenant);

--- a/src/backend/Shadowbrook.Domain/WaitlistOfferAggregate/IWaitlistOfferRepository.cs
+++ b/src/backend/Shadowbrook.Domain/WaitlistOfferAggregate/IWaitlistOfferRepository.cs
@@ -1,8 +1,9 @@
+using Shadowbrook.Domain.Common;
+
 namespace Shadowbrook.Domain.WaitlistOfferAggregate;
 
-public interface IWaitlistOfferRepository
+public interface IWaitlistOfferRepository : IRepository<WaitlistOffer>
 {
-    Task<WaitlistOffer?> GetByIdAsync(Guid id);
     Task<WaitlistOffer?> GetByTokenAsync(Guid token);
     Task<List<WaitlistOffer>> GetPendingByOpeningAsync(Guid openingId);
     void Add(WaitlistOffer offer);

--- a/src/backend/Shadowbrook.Domain/WaitlistOfferAggregate/WaitlistOffer.cs
+++ b/src/backend/Shadowbrook.Domain/WaitlistOfferAggregate/WaitlistOffer.cs
@@ -1,5 +1,4 @@
 using Shadowbrook.Domain.Common;
-using Shadowbrook.Domain.GolferAggregate;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Exceptions;
 
@@ -25,7 +24,7 @@ public class WaitlistOffer : Entity
 
     private WaitlistOffer() { } // EF
 
-    public static WaitlistOffer Create(
+    internal static WaitlistOffer Create(
         Guid openingId,
         Guid golferWaitlistEntryId,
         Guid golferId,

--- a/src/backend/Shadowbrook.Domain/WaitlistServices/WaitlistMatchingService.cs
+++ b/src/backend/Shadowbrook.Domain/WaitlistServices/WaitlistMatchingService.cs
@@ -3,7 +3,9 @@ using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 
 namespace Shadowbrook.Domain.WaitlistServices;
 
-public class WaitlistMatchingService(IGolferWaitlistEntryRepository entryRepository)
+public class WaitlistMatchingService(
+    IGolferWaitlistEntryRepository entryRepository,
+    ITeeTimeOpeningRepository openingRepository)
 {
     public async Task<List<GolferWaitlistEntry>> FindEligibleEntriesAsync(
         TeeTimeOpening opening, CancellationToken ct = default)
@@ -14,5 +16,12 @@ public class WaitlistMatchingService(IGolferWaitlistEntryRepository entryReposit
             opening.TeeTime.Time,
             opening.SlotsRemaining,
             ct);
+    }
+
+    public async Task<TeeTimeOpening?> FindOpeningForGolferAsync(
+        GolferWaitlistEntry entry, Guid courseId, DateOnly date, CancellationToken ct = default)
+    {
+        var openings = await openingRepository.FindActiveOpeningsForCourseDateAsync(courseId, date, ct);
+        return openings.FirstOrDefault(o => o.IsInGolferWindow(entry));
     }
 }

--- a/src/backend/Shadowbrook.Domain/WaitlistServices/WaitlistMatchingService.cs
+++ b/src/backend/Shadowbrook.Domain/WaitlistServices/WaitlistMatchingService.cs
@@ -1,6 +1,5 @@
 using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
-using Shadowbrook.Domain.TeeTimeOpeningAggregate.Exceptions;
 
 namespace Shadowbrook.Domain.WaitlistServices;
 
@@ -9,11 +8,6 @@ public class WaitlistMatchingService(IGolferWaitlistEntryRepository entryReposit
     public async Task<List<GolferWaitlistEntry>> FindEligibleEntriesAsync(
         TeeTimeOpening opening, CancellationToken ct = default)
     {
-        if (opening.Status != TeeTimeOpeningStatus.Open)
-        {
-            throw new OpeningNotAvailableException(opening.Id);
-        }
-
         return await entryRepository.FindEligibleEntriesAsync(
             opening.CourseId,
             opening.TeeTime.Date,

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/ExpireTeeTimeOpeningHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/ExpireTeeTimeOpeningHandlerTests.cs
@@ -1,6 +1,5 @@
 using NSubstitute;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
-using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/FindAndOfferEligibleGolfersHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/FindAndOfferEligibleGolfersHandlerTests.cs
@@ -29,7 +29,7 @@ public class FindAndOfferEligibleGolfersHandlerTests
         this.timeProvider.GetCurrentDate().Returns(new DateOnly(2026, 3, 25));
         this.timeProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(new DateOnly(2026, 3, 25));
         this.shortCodeGen.GenerateAsync(Arg.Any<DateOnly>()).Returns("1234");
-        this.matchingService = new WaitlistMatchingService(this.entryRepo);
+        this.matchingService = new WaitlistMatchingService(this.entryRepo, this.openingRepo);
     }
 
     private async Task<WalkUpGolferWaitlistEntry> CreateEntryAsync(Golfer golfer, int groupSize = 1)

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/FindAndOfferEligibleGolfersHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/FindAndOfferEligibleGolfersHandlerTests.cs
@@ -55,6 +55,24 @@ public class FindAndOfferEligibleGolfersHandlerTests
     }
 
     [Fact]
+    public async Task Handle_OpeningNotOpen_LogsAndReturnsWithoutCallingMatchingService()
+    {
+        var opening = TeeTimeOpening.Create(
+            Guid.NewGuid(), new DateOnly(2026, 3, 25), new TimeOnly(14, 30), 3, true, this.timeProvider);
+        opening.Expire(this.timeProvider);
+        this.openingRepo.GetByIdAsync(opening.Id).Returns(opening);
+
+        await FindAndOfferEligibleGolfersHandler.Handle(
+            new FindAndOfferEligibleGolfers(opening.Id, 3),
+            this.openingRepo, this.matchingService, this.offerRepo,
+            this.timeProvider, NullLogger.Instance, CancellationToken.None);
+
+        await this.entryRepo.DidNotReceive().FindEligibleEntriesAsync(
+            Arg.Any<Guid>(), Arg.Any<DateOnly>(), Arg.Any<TimeOnly>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        this.offerRepo.DidNotReceive().Add(Arg.Any<WaitlistOffer>());
+    }
+
+    [Fact]
     public async Task Handle_NoEligibleEntries_DoesNothing()
     {
         var opening = TeeTimeOpening.Create(

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/MarkOfferStaleHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/MarkOfferStaleHandlerTests.cs
@@ -18,9 +18,10 @@ public class MarkOfferStaleHandlerTests
         this.timeProvider.GetCurrentTimestamp().Returns(DateTimeOffset.UtcNow);
     }
 
-    private WaitlistOffer CreatePendingOffer(Guid openingId)
+    private async Task<WaitlistOffer> CreatePendingOfferAsync()
     {
-        var offer = WaitlistOffer.Create(openingId, Guid.NewGuid(), Guid.NewGuid(), 1, true, Guid.NewGuid(), new DateOnly(2026, 3, 25), new TimeOnly(10, 0), this.timeProvider);
+        var opening = WaitlistTestHelpers.CreateOpening(this.timeProvider);
+        var offer = await WaitlistTestHelpers.CreateOfferAsync(this.timeProvider, opening, groupSize: 1);
         offer.ClearDomainEvents();
         return offer;
     }
@@ -28,11 +29,10 @@ public class MarkOfferStaleHandlerTests
     [Fact]
     public async Task Handle_PendingOffer_MarksStaleAndRaisesDomainEvent()
     {
-        var openingId = Guid.NewGuid();
-        var offer = CreatePendingOffer(openingId);
+        var offer = await CreatePendingOfferAsync();
         this.offerRepo.GetByIdAsync(offer.Id).Returns(offer);
 
-        var command = new MarkOfferStale(offer.Id, openingId);
+        var command = new MarkOfferStale(offer.Id, offer.OpeningId);
 
         await MarkOfferStaleHandler.Handle(command, this.offerRepo, NullLogger.Instance);
 
@@ -41,19 +41,18 @@ public class MarkOfferStaleHandlerTests
         var domainEvent = Assert.Single(offer.DomainEvents);
         var stale = Assert.IsType<WaitlistOfferStale>(domainEvent);
         Assert.Equal(offer.Id, stale.WaitlistOfferId);
-        Assert.Equal(openingId, stale.OpeningId);
+        Assert.Equal(offer.OpeningId, stale.OpeningId);
     }
 
     [Fact]
     public async Task Handle_AlreadyRejectedOffer_LogsAndSkips()
     {
-        var openingId = Guid.NewGuid();
-        var offer = CreatePendingOffer(openingId);
+        var offer = await CreatePendingOfferAsync();
         offer.Reject("already handled");
         offer.ClearDomainEvents();
         this.offerRepo.GetByIdAsync(offer.Id).Returns(offer);
 
-        var command = new MarkOfferStale(offer.Id, openingId);
+        var command = new MarkOfferStale(offer.Id, offer.OpeningId);
 
         await MarkOfferStaleHandler.Handle(command, this.offerRepo, NullLogger.Instance);
 

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/MarkOfferStaleHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/MarkOfferStaleHandlerTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
-using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.WaitlistOfferAggregate;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/TeeTimeOpeningCancelledRejectOffersHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/TeeTimeOpeningCancelledRejectOffersHandlerTests.cs
@@ -39,21 +39,21 @@ public class TeeTimeOpeningCancelledRejectOffersHandlerTests
     [Fact]
     public async Task Handle_PendingOffers_RejectsEachWithCancellationReason()
     {
-        var openingId = Guid.NewGuid();
         var courseId = Guid.NewGuid();
         var date = new DateOnly(2026, 3, 26);
         var teeTime = new TimeOnly(10, 0);
-        var offer1 = WaitlistOffer.Create(openingId, Guid.NewGuid(), Guid.NewGuid(), 1, true, courseId, date, teeTime, this.timeProvider);
-        var offer2 = WaitlistOffer.Create(openingId, Guid.NewGuid(), Guid.NewGuid(), 2, true, courseId, date, teeTime, this.timeProvider);
+        var opening = WaitlistTestHelpers.CreateOpening(this.timeProvider, courseId: courseId, date: date, teeTime: teeTime);
+        var offer1 = await WaitlistTestHelpers.CreateOfferAsync(this.timeProvider, opening, groupSize: 1);
+        var offer2 = await WaitlistTestHelpers.CreateOfferAsync(this.timeProvider, opening, groupSize: 2);
         offer1.ClearDomainEvents();
         offer2.ClearDomainEvents();
 
-        this.offerRepo.GetPendingByOpeningAsync(openingId)
+        this.offerRepo.GetPendingByOpeningAsync(opening.Id)
             .Returns(new List<WaitlistOffer> { offer1, offer2 });
 
         var evt = new TeeTimeOpeningCancelled
         {
-            OpeningId = openingId,
+            OpeningId = opening.Id,
             CourseId = courseId,
             Date = date,
             TeeTime = teeTime,

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/TeeTimeOpeningFilledRejectOffersHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/TeeTimeOpeningFilledRejectOffersHandlerTests.cs
@@ -33,16 +33,16 @@ public class TeeTimeOpeningFilledRejectOffersHandlerTests
     [Fact]
     public async Task Handle_PendingOffers_RejectsEach()
     {
-        var openingId = Guid.NewGuid();
-        var offer1 = WaitlistOffer.Create(openingId, Guid.NewGuid(), Guid.NewGuid(), 1, true, Guid.NewGuid(), new DateOnly(2026, 3, 25), new TimeOnly(10, 0), this.timeProvider);
-        var offer2 = WaitlistOffer.Create(openingId, Guid.NewGuid(), Guid.NewGuid(), 2, true, Guid.NewGuid(), new DateOnly(2026, 3, 25), new TimeOnly(10, 0), this.timeProvider);
+        var opening = WaitlistTestHelpers.CreateOpening(this.timeProvider);
+        var offer1 = await WaitlistTestHelpers.CreateOfferAsync(this.timeProvider, opening, groupSize: 1);
+        var offer2 = await WaitlistTestHelpers.CreateOfferAsync(this.timeProvider, opening, groupSize: 2);
         offer1.ClearDomainEvents();
         offer2.ClearDomainEvents();
 
-        this.offerRepo.GetPendingByOpeningAsync(openingId)
+        this.offerRepo.GetPendingByOpeningAsync(opening.Id)
             .Returns(new List<WaitlistOffer> { offer1, offer2 });
 
-        var evt = new TeeTimeOpeningFilled { OpeningId = openingId };
+        var evt = new TeeTimeOpeningFilled { OpeningId = opening.Id };
 
         await TeeTimeOpeningFilledRejectOffersHandler.Handle(evt, this.offerRepo);
 

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/WaitlistTestHelpers.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/WaitlistTestHelpers.cs
@@ -1,0 +1,57 @@
+using NSubstitute;
+using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
+using Shadowbrook.Domain.GolferAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
+using Shadowbrook.Domain.TeeTimeOpeningAggregate;
+using Shadowbrook.Domain.WaitlistOfferAggregate;
+
+namespace Shadowbrook.Api.Tests.Features.Waitlist.Handlers;
+
+internal static class WaitlistTestHelpers
+{
+    /// <summary>
+    /// Creates a WaitlistOffer via the public domain API: WalkUpWaitlist.Join → entry.CreateOffer.
+    /// </summary>
+    internal static async Task<WaitlistOffer> CreateOfferAsync(
+        ITimeProvider timeProvider,
+        TeeTimeOpening opening,
+        int groupSize = 1)
+    {
+        var shortCodeGenerator = Substitute.For<IShortCodeGenerator>();
+        shortCodeGenerator.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC123");
+
+        var waitlistRepository = Substitute.For<ICourseWaitlistRepository>();
+
+        var entryRepository = Substitute.For<IGolferWaitlistEntryRepository>();
+        entryRepository.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
+
+        var joinProvider = Substitute.For<ITimeProvider>();
+        joinProvider.GetCurrentTimestamp().Returns(timeProvider.GetCurrentTimestamp());
+        joinProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(opening.TeeTime.Time);
+        joinProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(opening.TeeTime.Date);
+
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            opening.CourseId, opening.TeeTime.Date,
+            shortCodeGenerator, waitlistRepository, joinProvider);
+
+        var golfer = Golfer.Create("+15551234567", "Test", "Golfer");
+        var entry = await waitlist.Join(golfer, entryRepository, joinProvider, "UTC", groupSize);
+        return entry.CreateOffer(opening, timeProvider);
+    }
+
+    internal static TeeTimeOpening CreateOpening(
+        ITimeProvider timeProvider,
+        Guid? courseId = null,
+        DateOnly? date = null,
+        TimeOnly? teeTime = null,
+        int slotsAvailable = 4) =>
+        TeeTimeOpening.Create(
+            courseId ?? Guid.NewGuid(),
+            date ?? new DateOnly(2026, 3, 25),
+            teeTime ?? new TimeOnly(10, 0),
+            slotsAvailable,
+            operatorOwned: false,
+            timeProvider);
+}

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/WakeUpOfferPolicyHandlerTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Handlers/WakeUpOfferPolicyHandlerTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shadowbrook.Api.Features.Waitlist.Handlers;
+using Shadowbrook.Api.Features.Waitlist.Policies;
+using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
+using Shadowbrook.Domain.CourseWaitlistAggregate.Events;
+using Shadowbrook.Domain.GolferAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
+using Shadowbrook.Domain.TeeTimeOpeningAggregate;
+using Shadowbrook.Domain.WaitlistServices;
+
+namespace Shadowbrook.Api.Tests.Features.Waitlist.Handlers;
+
+public class WakeUpOfferPolicyHandlerTests
+{
+    private readonly ICourseWaitlistRepository waitlistRepo = Substitute.For<ICourseWaitlistRepository>();
+    private readonly IGolferWaitlistEntryRepository entryRepo = Substitute.For<IGolferWaitlistEntryRepository>();
+    private readonly ITeeTimeOpeningRepository openingRepo = Substitute.For<ITeeTimeOpeningRepository>();
+    private readonly ITimeProvider timeProvider = Substitute.For<ITimeProvider>();
+    private readonly IShortCodeGenerator shortCodeGen = Substitute.For<IShortCodeGenerator>();
+    private readonly WaitlistMatchingService matchingService;
+
+    private static readonly DateOnly Date = new(2026, 6, 1);
+    private static readonly Guid CourseId = Guid.NewGuid();
+
+    public WakeUpOfferPolicyHandlerTests()
+    {
+        this.timeProvider.GetCurrentTimestamp().Returns(new DateTimeOffset(2026, 3, 25, 10, 0, 0, TimeSpan.Zero));
+        this.timeProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(new TimeOnly(10, 0));
+        this.timeProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(new DateOnly(2026, 3, 25));
+        this.shortCodeGen.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC");
+        this.entryRepo.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
+        this.matchingService = new WaitlistMatchingService(this.entryRepo, this.openingRepo);
+    }
+
+    private async Task<(WalkUpWaitlist waitlist, GolferWaitlistEntry entry)> CreateWaitlistAndEntryAsync(
+        TimeOnly joinTime)
+    {
+        var joinProvider = Substitute.For<ITimeProvider>();
+        joinProvider.GetCurrentTimestamp()
+            .Returns(new DateTimeOffset(Date.ToDateTime(joinTime), TimeSpan.Zero));
+        joinProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(Date);
+        joinProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(joinTime);
+
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            CourseId, Date, this.shortCodeGen, this.waitlistRepo, joinProvider);
+
+        this.entryRepo.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
+
+        var golfer = Golfer.Create("+15551234567", "Test", "Golfer");
+        var entry = await waitlist.Join(golfer, this.entryRepo, joinProvider, "UTC");
+
+        return (waitlist, entry);
+    }
+
+    [Fact]
+    public async Task Handle_WaitlistNotFound_Throws()
+    {
+        var evt = new GolferJoinedWaitlist
+        {
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            CourseWaitlistId = Guid.NewGuid(),
+            GolferId = Guid.NewGuid()
+        };
+        this.waitlistRepo.GetByIdAsync(evt.CourseWaitlistId).Returns((CourseWaitlist?)null);
+
+        await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => GolferJoinedWaitlistWakeUpHandler.Handle(
+                evt, this.waitlistRepo, this.entryRepo, this.matchingService,
+                NullLogger.Instance, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_EntryNotFound_LogsAndReturnsNull()
+    {
+        var (waitlist, _) = await CreateWaitlistAndEntryAsync(new TimeOnly(9, 0));
+        var evt = new GolferJoinedWaitlist
+        {
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            CourseWaitlistId = waitlist.Id,
+            GolferId = Guid.NewGuid()
+        };
+        this.waitlistRepo.GetByIdAsync(waitlist.Id).Returns(waitlist);
+        this.entryRepo.GetByIdAsync(evt.GolferWaitlistEntryId).Returns((GolferWaitlistEntry?)null);
+
+        var result = await GolferJoinedWaitlistWakeUpHandler.Handle(
+            evt, this.waitlistRepo, this.entryRepo, this.matchingService,
+            NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Handle_NoActiveOpeningForGolfer_ReturnsNull()
+    {
+        var (waitlist, entry) = await CreateWaitlistAndEntryAsync(new TimeOnly(9, 0));
+        var evt = new GolferJoinedWaitlist
+        {
+            GolferWaitlistEntryId = entry.Id,
+            CourseWaitlistId = waitlist.Id,
+            GolferId = entry.GolferId
+        };
+        this.waitlistRepo.GetByIdAsync(waitlist.Id).Returns(waitlist);
+        this.entryRepo.GetByIdAsync(entry.Id).Returns(entry);
+        this.openingRepo
+            .FindActiveOpeningsForCourseDateAsync(CourseId, Date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening>());
+
+        var result = await GolferJoinedWaitlistWakeUpHandler.Handle(
+            evt, this.waitlistRepo, this.entryRepo, this.matchingService,
+            NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Handle_OpeningFoundInWindow_ReturnsWakeUpOfferPolicy()
+    {
+        // Entry window: 09:00 - 09:30; opening at 09:15 is inside the window
+        var (waitlist, entry) = await CreateWaitlistAndEntryAsync(new TimeOnly(9, 0));
+        var evt = new GolferJoinedWaitlist
+        {
+            GolferWaitlistEntryId = entry.Id,
+            CourseWaitlistId = waitlist.Id,
+            GolferId = entry.GolferId
+        };
+        this.waitlistRepo.GetByIdAsync(waitlist.Id).Returns(waitlist);
+        this.entryRepo.GetByIdAsync(entry.Id).Returns(entry);
+
+        var opening = TeeTimeOpening.Create(CourseId, Date, new TimeOnly(9, 15), 2, false, this.timeProvider);
+        this.openingRepo
+            .FindActiveOpeningsForCourseDateAsync(CourseId, Date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening> { opening });
+
+        var result = await GolferJoinedWaitlistWakeUpHandler.Handle(
+            evt, this.waitlistRepo, this.entryRepo, this.matchingService,
+            NullLogger.Instance, CancellationToken.None);
+
+        var wakeUp = Assert.IsType<WakeUpOfferPolicy>(result);
+        Assert.Equal(opening.Id, wakeUp.OpeningId);
+    }
+
+    [Fact]
+    public async Task Handle_OpeningOutsideWindow_ReturnsNull()
+    {
+        // Entry window: 09:00 - 09:30; opening at 11:00 is outside the window
+        var (waitlist, entry) = await CreateWaitlistAndEntryAsync(new TimeOnly(9, 0));
+        var evt = new GolferJoinedWaitlist
+        {
+            GolferWaitlistEntryId = entry.Id,
+            CourseWaitlistId = waitlist.Id,
+            GolferId = entry.GolferId
+        };
+        this.waitlistRepo.GetByIdAsync(waitlist.Id).Returns(waitlist);
+        this.entryRepo.GetByIdAsync(entry.Id).Returns(entry);
+
+        var opening = TeeTimeOpening.Create(CourseId, Date, new TimeOnly(11, 0), 2, false, this.timeProvider);
+        this.openingRepo
+            .FindActiveOpeningsForCourseDateAsync(CourseId, Date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening> { opening });
+
+        var result = await GolferJoinedWaitlistWakeUpHandler.Handle(
+            evt, this.waitlistRepo, this.entryRepo, this.matchingService,
+            NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicyTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicyTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
+using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.Common;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/WaitlistOfferResponsePolicyTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/WaitlistOfferResponsePolicyTests.cs
@@ -1,3 +1,4 @@
+using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
 

--- a/tests/Shadowbrook.Domain.Tests/TeeTimeOpeningAggregate/TeeTimeOpeningTests.cs
+++ b/tests/Shadowbrook.Domain.Tests/TeeTimeOpeningAggregate/TeeTimeOpeningTests.cs
@@ -1,5 +1,8 @@
 using NSubstitute;
 using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
+using Shadowbrook.Domain.GolferAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Exceptions;
@@ -346,5 +349,92 @@ public class TeeTimeOpeningTests
         Assert.Equal(TeeTimeOpeningStatus.Cancelled, opening.Status);
         Assert.Null(opening.ExpiredAt);
         Assert.Empty(opening.DomainEvents);
+    }
+
+    // IsInGolferWindow tests
+    // Opening tee time: 2026-06-01 09:00
+
+    // joinTime controls WindowStart; WindowEnd = joinTime + 30 min (set by WalkUpWaitlist.Join)
+    private async Task<GolferWaitlistEntry> CreateEntryWithJoinTimeAsync(DateTime joinTime)
+    {
+        var shortCodeGenerator = Substitute.For<IShortCodeGenerator>();
+        shortCodeGenerator.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC");
+
+        var waitlistRepo = Substitute.For<ICourseWaitlistRepository>();
+        var entryRepo = Substitute.For<IGolferWaitlistEntryRepository>();
+        entryRepo.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
+
+        var joinProvider = Substitute.For<ITimeProvider>();
+        joinProvider.GetCurrentTimestamp().Returns(new DateTimeOffset(joinTime, TimeSpan.Zero));
+        joinProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(DateOnly.FromDateTime(joinTime));
+        joinProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(TimeOnly.FromDateTime(joinTime));
+
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            Guid.NewGuid(), new DateOnly(2026, 6, 1), shortCodeGenerator, waitlistRepo, joinProvider);
+
+        var golfer = Golfer.Create("+15551234567", "Test", "Golfer");
+        return await waitlist.Join(golfer, entryRepo, joinProvider, "UTC", groupSize: 1);
+    }
+
+    [Fact]
+    public async Task IsInGolferWindow_WhenTeeTimeWithinWindow_ReturnsTrue()
+    {
+        // Opening tee time: 2026-06-01 09:00
+        // Window: 08:45 - 09:15 (golfer joined at 08:45, +30 min = 09:15)
+        var opening = CreateOpening(); // 09:00
+        var joinTime = new DateTime(2026, 6, 1, 8, 45, 0);
+        var entry = await CreateEntryWithJoinTimeAsync(joinTime);
+
+        Assert.True(opening.IsInGolferWindow(entry));
+    }
+
+    [Fact]
+    public async Task IsInGolferWindow_WhenTeeTimeBeforeWindow_ReturnsFalse()
+    {
+        // Opening tee time: 2026-06-01 09:00
+        // Window: 09:15 - 09:45 (golfer joined at 09:15, after the tee time)
+        var opening = CreateOpening(); // 09:00
+        var joinTime = new DateTime(2026, 6, 1, 9, 15, 0);
+        var entry = await CreateEntryWithJoinTimeAsync(joinTime);
+
+        Assert.False(opening.IsInGolferWindow(entry));
+    }
+
+    [Fact]
+    public async Task IsInGolferWindow_WhenTeeTimeAfterWindow_ReturnsFalse()
+    {
+        // Opening tee time: 2026-06-01 09:00
+        // Window: 07:00 - 07:30 (golfer's window expired before tee time)
+        var opening = CreateOpening(); // 09:00
+        var joinTime = new DateTime(2026, 6, 1, 7, 0, 0);
+        var entry = await CreateEntryWithJoinTimeAsync(joinTime);
+
+        Assert.False(opening.IsInGolferWindow(entry));
+    }
+
+    [Fact]
+    public async Task IsInGolferWindow_WhenTeeTimeAtWindowStart_ReturnsTrue()
+    {
+        // Opening tee time: 2026-06-01 09:00
+        // Window: 09:00 - 09:30 (inclusive lower boundary)
+        var opening = CreateOpening(); // 09:00
+        var joinTime = new DateTime(2026, 6, 1, 9, 0, 0);
+        var entry = await CreateEntryWithJoinTimeAsync(joinTime);
+
+        Assert.True(opening.IsInGolferWindow(entry));
+    }
+
+    [Fact]
+    public async Task IsInGolferWindow_WhenTeeTimeAtWindowEnd_ReturnsTrue()
+    {
+        // Opening tee time: 2026-06-01 09:00
+        // Window: 08:30 - 09:00 (inclusive upper boundary)
+        // Join at 08:30 → window end = 09:00
+        var opening = CreateOpening(); // 09:00
+        var joinTime = new DateTime(2026, 6, 1, 8, 30, 0);
+        var entry = await CreateEntryWithJoinTimeAsync(joinTime);
+
+        Assert.True(opening.IsInGolferWindow(entry));
     }
 }

--- a/tests/Shadowbrook.Domain.Tests/WaitlistOfferAggregate/WaitlistOfferTests.cs
+++ b/tests/Shadowbrook.Domain.Tests/WaitlistOfferAggregate/WaitlistOfferTests.cs
@@ -1,5 +1,9 @@
 using NSubstitute;
 using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
+using Shadowbrook.Domain.GolferAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
+using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 using Shadowbrook.Domain.WaitlistOfferAggregate;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Exceptions;
@@ -8,43 +12,63 @@ namespace Shadowbrook.Domain.Tests.WaitlistOfferAggregate;
 
 public class WaitlistOfferTests
 {
+    private readonly IShortCodeGenerator shortCodeGenerator = Substitute.For<IShortCodeGenerator>();
+    private readonly ICourseWaitlistRepository waitlistRepository = Substitute.For<ICourseWaitlistRepository>();
+    private readonly IGolferWaitlistEntryRepository entryRepository = Substitute.For<IGolferWaitlistEntryRepository>();
     private readonly ITimeProvider timeProvider = Substitute.For<ITimeProvider>();
 
     public WaitlistOfferTests()
     {
+        this.shortCodeGenerator.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC123");
+        this.entryRepository.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
         this.timeProvider.GetCurrentTimestamp().Returns(DateTimeOffset.UtcNow);
+        this.timeProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(new TimeOnly(10, 0));
+        this.timeProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(new DateOnly(2026, 3, 25));
     }
 
-    private WaitlistOffer CreateOffer(Guid? openingId = null) =>
-        WaitlistOffer.Create(
-            openingId ?? Guid.NewGuid(),
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            2,
-            true,
-            Guid.NewGuid(),
-            new DateOnly(2026, 3, 25),
-            new TimeOnly(10, 0),
+    private async Task<GolferWaitlistEntry> CreateEntryAsync(int groupSize = 2)
+    {
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            Guid.NewGuid(), new DateOnly(2026, 3, 25),
+            this.shortCodeGenerator, this.waitlistRepository, this.timeProvider);
+
+        var golfer = Golfer.Create("+15551234567", "Test", "Golfer");
+        return await waitlist.Join(golfer, this.entryRepository, this.timeProvider, "UTC", groupSize);
+    }
+
+    private TeeTimeOpening CreateOpening(Guid? courseId = null, DateOnly? date = null, TimeOnly? teeTime = null) =>
+        TeeTimeOpening.Create(
+            courseId ?? Guid.NewGuid(),
+            date ?? new DateOnly(2026, 3, 25),
+            teeTime ?? new TimeOnly(10, 0),
+            slotsAvailable: 4,
+            operatorOwned: false,
             this.timeProvider);
 
-    [Fact]
-    public void Create_SetsPropertiesAndGeneratesIds()
+    private async Task<WaitlistOffer> CreateOfferAsync(TeeTimeOpening? opening = null)
     {
-        var openingId = Guid.NewGuid();
-        var entryId = Guid.NewGuid();
-        var golferId = Guid.NewGuid();
+        var entry = await CreateEntryAsync();
+        return entry.CreateOffer(opening ?? CreateOpening(), this.timeProvider);
+    }
+
+    [Fact]
+    public async Task Create_SetsPropertiesAndGeneratesIds()
+    {
         var courseId = Guid.NewGuid();
         var date = new DateOnly(2026, 3, 25);
         var teeTime = new TimeOnly(10, 0);
+        var entry = await CreateEntryAsync(groupSize: 2);
+        var opening = CreateOpening(courseId: courseId, date: date, teeTime: teeTime);
 
-        var offer = WaitlistOffer.Create(openingId, entryId, golferId, 2, true, courseId, date, teeTime, this.timeProvider);
+        var offer = entry.CreateOffer(opening, this.timeProvider);
 
         Assert.NotEqual(Guid.Empty, offer.Id);
         Assert.NotEqual(Guid.Empty, offer.BookingId);
         Assert.NotEqual(Guid.Empty, offer.Token);
-        Assert.Equal(openingId, offer.OpeningId);
-        Assert.Equal(entryId, offer.GolferWaitlistEntryId);
-        Assert.Equal(golferId, offer.GolferId);
+        Assert.Equal(opening.Id, offer.OpeningId);
+        Assert.Equal(entry.Id, offer.GolferWaitlistEntryId);
+        Assert.Equal(entry.GolferId, offer.GolferId);
         Assert.Equal(2, offer.GroupSize);
         Assert.True(offer.IsWalkUp);
         Assert.Equal(OfferStatus.Pending, offer.Status);
@@ -55,24 +79,23 @@ public class WaitlistOfferTests
     }
 
     [Fact]
-    public void Create_RaisesWaitlistOfferCreatedEvent()
+    public async Task Create_RaisesWaitlistOfferCreatedEvent()
     {
-        var openingId = Guid.NewGuid();
-        var entryId = Guid.NewGuid();
-        var golferId = Guid.NewGuid();
         var courseId = Guid.NewGuid();
         var date = new DateOnly(2026, 3, 25);
         var teeTime = new TimeOnly(10, 0);
+        var entry = await CreateEntryAsync(groupSize: 2);
+        var opening = CreateOpening(courseId: courseId, date: date, teeTime: teeTime);
 
-        var offer = WaitlistOffer.Create(openingId, entryId, golferId, 2, true, courseId, date, teeTime, this.timeProvider);
+        var offer = entry.CreateOffer(opening, this.timeProvider);
 
         var domainEvent = Assert.Single(offer.DomainEvents);
         var created = Assert.IsType<WaitlistOfferCreated>(domainEvent);
         Assert.Equal(offer.Id, created.WaitlistOfferId);
         Assert.Equal(offer.BookingId, created.BookingId);
-        Assert.Equal(openingId, created.OpeningId);
-        Assert.Equal(entryId, created.GolferWaitlistEntryId);
-        Assert.Equal(golferId, created.GolferId);
+        Assert.Equal(opening.Id, created.OpeningId);
+        Assert.Equal(entry.Id, created.GolferWaitlistEntryId);
+        Assert.Equal(entry.GolferId, created.GolferId);
         Assert.Equal(2, created.GroupSize);
         Assert.True(created.IsWalkUp);
         Assert.Equal(courseId, created.CourseId);
@@ -81,9 +104,9 @@ public class WaitlistOfferTests
     }
 
     [Fact]
-    public void Reject_PendingOffer_SetsRejectedWithReason()
+    public async Task Reject_PendingOffer_SetsRejectedWithReason()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
         offer.ClearDomainEvents();
 
         offer.Reject("Tee time has been filled.");
@@ -98,10 +121,10 @@ public class WaitlistOfferTests
     }
 
     [Fact]
-    public void MarkNotified_SetsNotifiedAtAndRaisesEvent()
+    public async Task MarkNotified_SetsNotifiedAtAndRaisesEvent()
     {
-        var openingId = Guid.NewGuid();
-        var offer = CreateOffer(openingId);
+        var opening = CreateOpening();
+        var offer = await CreateOfferAsync(opening);
         offer.ClearDomainEvents();
 
         offer.MarkNotified(this.timeProvider);
@@ -110,30 +133,30 @@ public class WaitlistOfferTests
         var domainEvent = Assert.Single(offer.DomainEvents);
         var sent = Assert.IsType<WaitlistOfferSent>(domainEvent);
         Assert.Equal(offer.Id, sent.WaitlistOfferId);
-        Assert.Equal(openingId, sent.OpeningId);
+        Assert.Equal(opening.Id, sent.OpeningId);
     }
 
     [Fact]
-    public void MarkNotified_AlreadyNotified_Throws()
+    public async Task MarkNotified_AlreadyNotified_Throws()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
         offer.MarkNotified(this.timeProvider);
 
         Assert.Throws<OfferAlreadyNotifiedException>(() => offer.MarkNotified(this.timeProvider));
     }
 
     [Fact]
-    public void Create_SetsIsStaleToFalse()
+    public async Task Create_SetsIsStaleToFalse()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
 
         Assert.False(offer.IsStale);
     }
 
     [Fact]
-    public void MarkStale_PendingOffer_SetsIsStaleAndRaisesEvent()
+    public async Task MarkStale_PendingOffer_SetsIsStaleAndRaisesEvent()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
         offer.ClearDomainEvents();
 
         offer.MarkStale();
@@ -147,9 +170,9 @@ public class WaitlistOfferTests
     }
 
     [Fact]
-    public void MarkStale_AlreadyStale_IsIdempotent()
+    public async Task MarkStale_AlreadyStale_IsIdempotent()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
         offer.MarkStale();
         offer.ClearDomainEvents();
 
@@ -160,9 +183,9 @@ public class WaitlistOfferTests
     }
 
     [Fact]
-    public void MarkStale_RejectedOffer_IsIdempotent()
+    public async Task MarkStale_RejectedOffer_IsIdempotent()
     {
-        var offer = CreateOffer();
+        var offer = await CreateOfferAsync();
         offer.Reject("taken");
         offer.ClearDomainEvents();
 

--- a/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistMatchingServiceTests.cs
+++ b/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistMatchingServiceTests.cs
@@ -13,6 +13,9 @@ public class WaitlistMatchingServiceTests
     private readonly IGolferWaitlistEntryRepository entryRepository =
         Substitute.For<IGolferWaitlistEntryRepository>();
 
+    private readonly ITeeTimeOpeningRepository openingRepository =
+        Substitute.For<ITeeTimeOpeningRepository>();
+
     private readonly IShortCodeGenerator shortCodeGenerator = Substitute.For<IShortCodeGenerator>();
     private readonly ICourseWaitlistRepository waitlistRepository = Substitute.For<ICourseWaitlistRepository>();
     private readonly ITimeProvider timeProvider = Substitute.For<ITimeProvider>();
@@ -27,7 +30,7 @@ public class WaitlistMatchingServiceTests
         this.shortCodeGenerator.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC123");
         this.entryRepository.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
             .Returns((GolferWaitlistEntry?)null);
-        this.sut = new WaitlistMatchingService(this.entryRepository);
+        this.sut = new WaitlistMatchingService(this.entryRepository, this.openingRepository);
     }
 
     private async Task<GolferWaitlistEntry> CreateRealEntryAsync()
@@ -82,6 +85,103 @@ public class WaitlistMatchingServiceTests
         var result = await this.sut.FindEligibleEntriesAsync(opening);
 
         Assert.Same(expected, result);
+    }
+
+    // FindOpeningForGolferAsync tests
+    // Entry window is set from join time (timeProvider at 10:00) + 30 min = [10:00, 10:30].
+
+    private async Task<GolferWaitlistEntry> CreateEntryWithWindowAsync(TimeOnly joinTime, DateOnly date)
+    {
+        var joinProvider = Substitute.For<ITimeProvider>();
+        joinProvider.GetCurrentTimestamp().Returns(new DateTimeOffset(date.ToDateTime(joinTime), TimeSpan.Zero));
+        joinProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(date);
+        joinProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(joinTime);
+
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            Guid.NewGuid(), date, this.shortCodeGenerator, this.waitlistRepository, joinProvider);
+
+        var golfer = Golfer.Create("+15559990000", "Test", "Golfer");
+        return await waitlist.Join(golfer, this.entryRepository, joinProvider, "UTC");
+    }
+
+    [Fact]
+    public async Task FindOpeningForGolfer_NoActiveOpenings_ReturnsNull()
+    {
+        var courseId = Guid.NewGuid();
+        var date = new DateOnly(2026, 6, 1);
+        var entry = await CreateEntryWithWindowAsync(new TimeOnly(9, 0), date);
+
+        this.openingRepository
+            .FindActiveOpeningsForCourseDateAsync(Arg.Any<Guid>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening>());
+
+        var result = await this.sut.FindOpeningForGolferAsync(entry, courseId, date);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindOpeningForGolfer_OpeningOutsideWindow_ReturnsNull()
+    {
+        var courseId = Guid.NewGuid();
+        var date = new DateOnly(2026, 6, 1);
+
+        // Entry window: 09:00 - 09:30
+        var entry = await CreateEntryWithWindowAsync(new TimeOnly(9, 0), date);
+
+        // Opening at 10:00 — outside golfer's window
+        var opening = TeeTimeOpening.Create(courseId, date, new TimeOnly(10, 0), 2, false, this.timeProvider);
+        this.openingRepository
+            .FindActiveOpeningsForCourseDateAsync(courseId, date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening> { opening });
+
+        var result = await this.sut.FindOpeningForGolferAsync(entry, courseId, date);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindOpeningForGolfer_OpeningInsideWindow_ReturnsOpening()
+    {
+        var courseId = Guid.NewGuid();
+        var date = new DateOnly(2026, 6, 1);
+
+        // Entry window: 09:00 - 09:30
+        var entry = await CreateEntryWithWindowAsync(new TimeOnly(9, 0), date);
+
+        // Opening at 09:15 — inside golfer's window
+        var opening = TeeTimeOpening.Create(courseId, date, new TimeOnly(9, 15), 2, false, this.timeProvider);
+        this.openingRepository
+            .FindActiveOpeningsForCourseDateAsync(courseId, date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening> { opening });
+
+        var result = await this.sut.FindOpeningForGolferAsync(entry, courseId, date);
+
+        Assert.NotNull(result);
+        Assert.Equal(opening.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task FindOpeningForGolfer_MultipleOpenings_ReturnsFirstMatchingWindow()
+    {
+        var courseId = Guid.NewGuid();
+        var date = new DateOnly(2026, 6, 1);
+
+        // Entry window: 09:00 - 09:30
+        var entry = await CreateEntryWithWindowAsync(new TimeOnly(9, 0), date);
+
+        // Opening at 08:00 — before window; opening at 09:10 — inside window
+        var outsideOpening = TeeTimeOpening.Create(courseId, date, new TimeOnly(8, 0), 2, false, this.timeProvider);
+        var insideOpening = TeeTimeOpening.Create(courseId, date, new TimeOnly(9, 10), 2, false, this.timeProvider);
+
+        this.openingRepository
+            .FindActiveOpeningsForCourseDateAsync(courseId, date, Arg.Any<CancellationToken>())
+            .Returns(new List<TeeTimeOpening> { outsideOpening, insideOpening });
+
+        var result = await this.sut.FindOpeningForGolferAsync(entry, courseId, date);
+
+        Assert.NotNull(result);
+        Assert.Equal(insideOpening.Id, result.Id);
     }
 
 }

--- a/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistMatchingServiceTests.cs
+++ b/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistMatchingServiceTests.cs
@@ -4,7 +4,6 @@ using Shadowbrook.Domain.CourseWaitlistAggregate;
 using Shadowbrook.Domain.GolferAggregate;
 using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
-using Shadowbrook.Domain.TeeTimeOpeningAggregate.Exceptions;
 using Shadowbrook.Domain.WaitlistServices;
 
 namespace Shadowbrook.Domain.Tests.WaitlistServices;
@@ -85,15 +84,4 @@ public class WaitlistMatchingServiceTests
         Assert.Same(expected, result);
     }
 
-    [Fact]
-    public async Task FindEligibleEntries_WhenOpeningNotOpen_ThrowsOpeningNotAvailable()
-    {
-        var opening = TeeTimeOpening.Create(
-            Guid.NewGuid(), new DateOnly(2026, 6, 15), new TimeOnly(8, 0),
-            slotsAvailable: 2, operatorOwned: true, timeProvider: this.timeProvider);
-        opening.Expire(this.timeProvider);
-
-        await Assert.ThrowsAsync<OpeningNotAvailableException>(
-            () => this.sut.FindEligibleEntriesAsync(opening));
-    }
 }

--- a/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistOfferClaimServiceTests.cs
+++ b/tests/Shadowbrook.Domain.Tests/WaitlistServices/WaitlistOfferClaimServiceTests.cs
@@ -1,5 +1,8 @@
 using NSubstitute;
 using Shadowbrook.Domain.Common;
+using Shadowbrook.Domain.CourseWaitlistAggregate;
+using Shadowbrook.Domain.GolferAggregate;
+using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
 using Shadowbrook.Domain.WaitlistOfferAggregate;
@@ -10,26 +13,33 @@ namespace Shadowbrook.Domain.Tests.WaitlistServices;
 
 public class WaitlistOfferClaimServiceTests
 {
+    private readonly IShortCodeGenerator shortCodeGenerator = Substitute.For<IShortCodeGenerator>();
+    private readonly ICourseWaitlistRepository waitlistRepository = Substitute.For<ICourseWaitlistRepository>();
+    private readonly IGolferWaitlistEntryRepository entryRepository = Substitute.For<IGolferWaitlistEntryRepository>();
     private readonly ITimeProvider timeProvider = Substitute.For<ITimeProvider>();
     private readonly WaitlistOfferClaimService sut;
 
     public WaitlistOfferClaimServiceTests()
     {
+        this.shortCodeGenerator.GenerateAsync(Arg.Any<DateOnly>()).Returns("ABC123");
+        this.entryRepository.GetActiveByWaitlistAndGolferAsync(Arg.Any<Guid>(), Arg.Any<Guid>())
+            .Returns((GolferWaitlistEntry?)null);
         this.timeProvider.GetCurrentTimestamp().Returns(new DateTimeOffset(2026, 3, 25, 10, 0, 0, TimeSpan.Zero));
+        this.timeProvider.GetCurrentTimeByTimeZone(Arg.Any<string>()).Returns(new TimeOnly(9, 0));
+        this.timeProvider.GetCurrentDateByTimeZone(Arg.Any<string>()).Returns(new DateOnly(2026, 6, 1));
         this.sut = new WaitlistOfferClaimService(this.timeProvider);
     }
 
-    private WaitlistOffer CreateOffer(Guid openingId, int groupSize = 2) =>
-        WaitlistOffer.Create(
-            openingId,
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            groupSize,
-            isWalkUp: true,
-            Guid.NewGuid(),
-            new DateOnly(2026, 6, 1),
-            new TimeOnly(9, 0),
-            this.timeProvider);
+    private async Task<WaitlistOffer> CreateOfferAsync(TeeTimeOpening opening, int groupSize = 2)
+    {
+        var waitlist = await WalkUpWaitlist.OpenAsync(
+            Guid.NewGuid(), new DateOnly(2026, 6, 1),
+            this.shortCodeGenerator, this.waitlistRepository, this.timeProvider);
+
+        var golfer = Golfer.Create("+15551234567", "Test", "Golfer");
+        var entry = await waitlist.Join(golfer, this.entryRepository, this.timeProvider, "UTC", groupSize);
+        return entry.CreateOffer(opening, this.timeProvider);
+    }
 
     private TeeTimeOpening CreateOpening(int slotsAvailable = 4) =>
         TeeTimeOpening.Create(
@@ -41,10 +51,10 @@ public class WaitlistOfferClaimServiceTests
             timeProvider: this.timeProvider);
 
     [Fact]
-    public void AcceptOffer_WhenClaimSucceeds_ReturnsSuccessResult()
+    public async Task AcceptOffer_WhenClaimSucceeds_ReturnsSuccessResult()
     {
         var opening = CreateOpening(slotsAvailable: 4);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -55,10 +65,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimSucceeds_OfferTransitionsToAccepted()
+    public async Task AcceptOffer_WhenClaimSucceeds_OfferTransitionsToAccepted()
     {
         var opening = CreateOpening(slotsAvailable: 4);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -68,10 +78,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimSucceeds_OfferRaisesWaitlistOfferAcceptedEvent()
+    public async Task AcceptOffer_WhenClaimSucceeds_OfferRaisesWaitlistOfferAcceptedEvent()
     {
         var opening = CreateOpening(slotsAvailable: 4);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -81,10 +91,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimSucceeds_OpeningRaisesSlotsClaimed()
+    public async Task AcceptOffer_WhenClaimSucceeds_OpeningRaisesSlotsClaimed()
     {
         var opening = CreateOpening(slotsAvailable: 4);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -94,10 +104,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimFails_ReturnsFailureResultWithReason()
+    public async Task AcceptOffer_WhenClaimFails_ReturnsFailureResultWithReason()
     {
         var opening = CreateOpening(slotsAvailable: 1);
-        var offer = CreateOffer(opening.Id, groupSize: 2); // group too large
+        var offer = await CreateOfferAsync(opening, groupSize: 2); // group too large
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -108,10 +118,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimFails_OfferTransitionsToRejectedWithReason()
+    public async Task AcceptOffer_WhenClaimFails_OfferTransitionsToRejectedWithReason()
     {
         var opening = CreateOpening(slotsAvailable: 1);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -122,10 +132,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenClaimFails_OpeningRaisesClaimRejectedEvent()
+    public async Task AcceptOffer_WhenClaimFails_OpeningRaisesClaimRejectedEvent()
     {
         var opening = CreateOpening(slotsAvailable: 1);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -135,11 +145,11 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_WhenOpeningNotOpen_ReturnsFailureAndRejectsOffer()
+    public async Task AcceptOffer_WhenOpeningNotOpen_ReturnsFailureAndRejectsOffer()
     {
         var opening = CreateOpening(slotsAvailable: 4);
         opening.Expire(this.timeProvider);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
 
@@ -152,10 +162,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_StaleOffer_WhenClaimSucceeds_ReturnsSuccessAndAccepts()
+    public async Task AcceptOffer_StaleOffer_WhenClaimSucceeds_ReturnsSuccessAndAccepts()
     {
         var opening = CreateOpening(slotsAvailable: 4);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         offer.MarkStale();
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();
@@ -168,10 +178,10 @@ public class WaitlistOfferClaimServiceTests
     }
 
     [Fact]
-    public void AcceptOffer_StaleOffer_WhenClaimFails_ReturnsFailureAndRejects()
+    public async Task AcceptOffer_StaleOffer_WhenClaimFails_ReturnsFailureAndRejects()
     {
         var opening = CreateOpening(slotsAvailable: 1);
-        var offer = CreateOffer(opening.Id, groupSize: 2);
+        var offer = await CreateOfferAsync(opening, groupSize: 2);
         offer.MarkStale();
         opening.ClearDomainEvents();
         offer.ClearDomainEvents();


### PR DESCRIPTION
## Summary

Processed all 9 `@cleanup` comments across 6 files, grouped into 6 logical commits:

1. **WaitlistOffer.Create → internal** — Enforces use of `GolferWaitlistEntry.CreateOffer()` factory path. Tests updated to construct offers through the proper aggregate factory.

2. **IRepository\<T\> generic interface** — All 8 repository interfaces now extend `IRepository<T>`, replacing 7 per-type `GetRequiredByIdAsync` extension methods with one generic.

3. **Command colocation** — Moved `ExpireTeeTimeOpening` and `MarkOfferStale` records from policy files into their handler files. Added convention to backend-conventions.md.

4. **FindAndOfferEligibleGolfers improvements** — Added `TeeTimeOpening.IsOpen` guard with early return, replaced `for` with `foreach`/`.Take()`, removed `OpeningNotAvailableException`.

5. **IOptions pattern** — Created `AppSettings` options class, replaced direct `IConfiguration` usage in `SendSmsHandler`. Added IOptions convention to backend-conventions.md.

6. **WakeUpOfferPolicyHandler refactor** — Replaced direct `DbContext` access with repositories. Added `TeeTimeOpening.IsInGolferWindow()` domain method and `WaitlistMatchingService.FindOpeningForGolferAsync()` for proper golfer window filtering.

### Behavior changes
- `FindAndOfferEligibleGolfers`: now logs warning + returns early when opening is not open (previously threw exception from matching service)
- `WakeUpOfferPolicyHandler`: now filters openings by golfer's time window (previously matched ANY open opening for the day)

### Conventions added
- Command colocation: records live with the code that has the `Handle` method
- IOptions pattern: always use strongly-typed options, never `IConfiguration["key"]` directly

## Test plan
- [x] All domain unit tests pass (100+)
- [x] All API unit tests pass (150+)
- [x] New tests added for `IsInGolferWindow`, `FindOpeningForGolferAsync`, `WakeUpOfferPolicyHandler`, `FindAndOfferEligibleGolfers` early return
- [x] Zero `@cleanup` comments remaining
- [x] `dotnet build` clean, `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)