### PR TITLE
Add seed admin email to root appsettings

### DIFF
--- a/src/backend/Shadowbrook.Api/appsettings.json
+++ b/src/backend/Shadowbrook.Api/appsettings.json
@@ -16,6 +16,9 @@
   "FeatureFlags": {
     "full-operator-app": "false"
   },
+  "Auth": {
+    "SeedAdminEmails": "aarongbenjamin@gmail.com"
+  },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "f74e8993-5f31-49cb-8772-a20a7f0cf2b6",


### PR DESCRIPTION
## Summary
- Adds `Auth:SeedAdminEmails` to the root `appsettings.json` so the admin account is provisioned in all environments (not just Development)
- Fixes 403 on `/auth/me` in the test environment caused by missing AppUser record

Closes no issue — hotfix for test environment access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)