### PR TITLE
chore: set container app min replicas to 1

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -161,7 +161,7 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: 1
         maxReplicas: 1
         rules: [
           {


### PR DESCRIPTION
## Summary
- Sets `minReplicas` from 0 to 1 in the container app Bicep module to keep the app warm and responsive

## Test plan
- [ ] Verify Bicep template compiles / validates
- [ ] Deploy to test environment and confirm the app stays running with 1 replica

🤖 Generated with [Claude Code](https://claude.com/claude-code)