### PR TITLE
chore: enable durable local queues in Wolverine

### DIFF
--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -21,10 +21,10 @@ using Shadowbrook.Domain.CourseAggregate;
 using Shadowbrook.Domain.CourseWaitlistAggregate;
 using Shadowbrook.Domain.GolferAggregate;
 using Shadowbrook.Domain.GolferWaitlistEntryAggregate;
+using Shadowbrook.Domain.Services;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate;
 using Shadowbrook.Domain.TenantAggregate;
 using Shadowbrook.Domain.WaitlistOfferAggregate;
-using Shadowbrook.Domain.Services;
 using Shadowbrook.Domain.WaitlistServices;
 using Wolverine;
 using Wolverine.EntityFrameworkCore;
@@ -121,6 +121,7 @@ builder.Host.UseWolverine(opts =>
 
     opts.UseEntityFrameworkCoreTransactions();
     opts.Policies.AutoApplyTransactions();
+    opts.Policies.UseDurableLocalQueues();
     opts.UseFluentValidation();
     opts.PublishDomainEventsFromEntityFrameworkCore<Entity, IDomainEvent>(e => e.DomainEvents);
 });


### PR DESCRIPTION
## What

Adds `opts.Policies.UseDurableLocalQueues()` to the Wolverine configuration in `Program.cs`, immediately after `AutoApplyTransactions()`.

## Why

Local queue messages are in-memory by default. Any domain event handler dispatched via a local queue — SMS confirmations, Entra invitation sends, saga starts — is lost if the app crashes or is restarted mid-processing. There is no retry, no dead-letter, no trace that it ever happened.

With durable local queues enabled, Wolverine persists these messages to the SQL Server inbox as part of the same EF Core transaction that saves the originating state change. The message is only dequeued and removed after the handler completes successfully. If the app crashes before that, the message is redelivered on restart.

## Impact

Negligible. The SQL Server persistence infrastructure (`UseSqlServerPersistenceAndTransport`) is already in place — this just opts local queues into the same durable store. Message volume is low (one or two events per booking/user action), so the additional DB writes are not a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)