### PR TITLE
fix: pass managed identity client ID to DefaultAzureCredential

### DIFF
--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -162,6 +162,7 @@ module containerApp 'modules/container-app.bicep' = {
     frontendUrl: 'https://${staticWebApp.outputs.defaultHostname}'
     corsOrigin: 'https://${staticWebApp.outputs.defaultHostname}'
     // Match main hostname and PR staging URLs (e.g., <name>-123.<region>.<slot>.azurestaticapps.net)
+    managedIdentityClientId: managedIdentity.outputs.clientId
     corsOriginPattern: '^https://${split(staticWebApp.outputs.defaultHostname, '.')[0]}(-\\d+)?\\..*\\.azurestaticapps\\.net$'
   }
 }

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -33,6 +33,9 @@ param corsOrigin string
 @description('Frontend URL used in outbound links (e.g., SMS messages with claim URLs)')
 param frontendUrl string
 
+@description('Client ID of the user-assigned managed identity (used for DefaultAzureCredential)')
+param managedIdentityClientId string
+
 @description('Regex pattern for allowed CORS origins (e.g., PR staging URLs). When set, takes precedence over corsOrigin.')
 param corsOriginPattern string = ''
 
@@ -108,6 +111,10 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               secretRef: 'app-insights-connection-string'
+            }
+            {
+              name: 'AzureAd__ManagedIdentityClientId'
+              value: managedIdentityClientId
             }
             // GC tuning: keep heap within budget and return memory to OS aggressively.
             // GCHeapHardLimit is set to 640MiB (~60% of the 1Gi container limit),

--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -152,7 +152,14 @@ if (useDevAuth)
 }
 else
 {
-    builder.Services.AddSingleton(_ => new GraphServiceClient(new DefaultAzureCredential()));
+    var managedIdentityClientId = builder.Configuration["AzureAd:ManagedIdentityClientId"];
+    var credential = string.IsNullOrEmpty(managedIdentityClientId)
+        ? new DefaultAzureCredential()
+        : new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        {
+            ManagedIdentityClientId = managedIdentityClientId
+        });
+    builder.Services.AddSingleton(_ => new GraphServiceClient(credential));
     builder.Services.AddScoped<IAppUserInvitationService, GraphAppUserInvitationService>();
 }
 builder.Services.AddScoped<IAppUserEmailUniquenessChecker, AppUserEmailUniquenessChecker>();


### PR DESCRIPTION
## Summary
- Passes the user-assigned managed identity client ID from Bicep infra into the container app as `AzureAd__ManagedIdentityClientId`
- Configures `DefaultAzureCredential` in `Program.cs` to use the explicit client ID when available, preventing it from picking the wrong identity
- Fixes Graph API auth failures in the container app

## Test plan
- [ ] Deploy to test and verify Graph API calls (Entra invitations) succeed
- [ ] Verify App Insights telemetry continues flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)