### PR TITLE
fix: bump container to 2 Gi and add GCRetainVM=0 to prevent OOM kills

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -84,8 +84,8 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
           name: 'shadowbrook-api'
           image: '${containerRegistryLoginServer}/shadowbrook:${imageTag}'
           resources: {
-            cpu: json('0.75')
-            memory: '1.5Gi'
+            cpu: json('1.0')
+            memory: '2Gi'
           }
           env: [
             {
@@ -117,15 +117,21 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
               value: managedIdentityClientId
             }
             // GC tuning: keep heap within budget and return memory to OS aggressively.
-            // GCHeapHardLimit is set to 640MiB (~60% of the 1Gi container limit),
+            // GCHeapHardLimit caps the managed heap at ~1 GiB (~50% of the 2 Gi container),
             // leaving headroom for native memory, thread stacks, and Wolverine codegen.
+            // GCRetainVM=0 forces Server GC to decommit pages after collection instead of
+            // holding them — critical in containers where retained pages count toward the limit.
             {
               name: 'DOTNET_GCConserveMemory'
               value: '7'
             }
             {
               name: 'DOTNET_GCHeapHardLimit'
-              value: '671088640'
+              value: '1073741824'
+            }
+            {
+              name: 'DOTNET_GCRetainVM'
+              value: '0'
             }
           ]
           probes: [


### PR DESCRIPTION
## Summary

- Bump container memory from 1.5 Gi → 2 Gi (CPU 0.75 → 1.0 to match Container Apps tier)
- Scale GCHeapHardLimit from 640 MiB → 1 GiB (maintains ~50% of container limit)
- Add `DOTNET_GCRetainVM=0` to force Server GC to decommit pages after collection

## Root cause

.NET Server GC retains virtual memory segments after collection. The Wolverine handler chain triggered by a single waitlist join (~10 cascading handlers) creates a burst of temporary allocations. After GC collects the objects, the pages stay committed — Private Bytes inflates by ~500 MB permanently. Repeated usage pushes past the 1.5 Gi container limit → OOM kill.

Evidence from monitoring:
- Fresh restart baseline: **455 MB**
- After single waitlist join: **1,037 MB peak → 986 MB settled (never recovered)**
- Previous OOM: memory climbed to **1,607 MB** and container was killed

## Test plan

- [ ] Merge and deploy to test environment
- [ ] Verify container starts with 2 Gi allocation
- [ ] Exercise waitlist join flow and monitor memory via App Insights
- [ ] Confirm memory recovers toward baseline after handler chain completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)