### PR TITLE
perf: disable EF Core OTEL instrumentation and tune GC for containers

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -117,17 +117,18 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
               value: managedIdentityClientId
             }
             // GC tuning: keep heap within budget and return memory to OS aggressively.
-            // GCHeapHardLimit caps the managed heap at ~1 GiB (~50% of the 2 Gi container),
-            // leaving headroom for native memory, thread stacks, and Wolverine codegen.
+            // GCHeapHardLimit caps the managed heap at 512 MiB — keeps the heap compact
+            // while leaving ~1.5 GiB for native memory, thread stacks, and burst headroom.
+            // GCConserveMemory=9 (max) forces the most aggressive compaction/decommit.
             // GCRetainVM=0 forces Server GC to decommit pages after collection instead of
             // holding them — critical in containers where retained pages count toward the limit.
             {
               name: 'DOTNET_GCConserveMemory'
-              value: '7'
+              value: '9'
             }
             {
               name: 'DOTNET_GCHeapHardLimit'
-              value: '1073741824'
+              value: '536870912'
             }
             {
               name: 'DOTNET_GCRetainVM'

--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -64,9 +64,9 @@ if (!string.IsNullOrEmpty(appInsightsConnectionString))
             .AddAspNetCoreInstrumentation(o =>
                 o.Filter = context => context.Request.Path != "/health")
             .AddHttpClientInstrumentation()
-            .AddEntityFrameworkCoreInstrumentation(o =>
-                o.EnrichWithIDbCommand = (activity, _) =>
-                    activity.SetTag("db.statement", null))
+            // EF Core instrumentation disabled — Wolverine's inbox/outbox polling generates
+            // ~232 dependency spans/min (~334K/day) with zero diagnostic value, consuming
+            // significant native memory in the OTEL pipeline that GC cannot reclaim.
             .AddSource("Wolverine"))
         .WithMetrics(metrics => metrics
             .AddAspNetCoreInstrumentation()


### PR DESCRIPTION
## Summary

- Disable EF Core OpenTelemetry instrumentation — eliminates ~334K noisy dependency spans/day from Wolverine polling
- Lower GCHeapHardLimit from 1 GiB to 512 MiB — forces heap compaction instead of expanding to limit
- Raise GCConserveMemory from 7 to 9 (maximum aggressiveness)

## Context

Follow-up to #353. Memory profiling showed:

| Metric | Before | After #353 | This PR (expected) |
|--------|--------|-----------|-------------------|
| Baseline | 453 MB | 274 MB | ~274 MB |
| After 3 waitlist joins | OOM killed | 1,090 MB (stable) | ~750 MB |
| Recovery | Never | Never | Partial recovery expected |

The ~585 MB of non-recoverable memory is native (outside GC), primarily from the OTEL pipeline processing EF Core dependency spans. Wolverine's inbox/outbox polling creates ~4 SQL calls/sec even when idle.

## Test plan

- [ ] CI builds and deploys new image
- [ ] Verify no EF Core dependency spans in App Insights (`dependencies | where name contains "SQL"` should drop from 232/min to near zero)
- [ ] Run waitlist join flow and monitor Private Bytes via App Insights
- [ ] Confirm post-burst memory is lower than 1,090 MB

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)