### PR TITLE
perf: replace OTEL SDK with Serilog App Insights sink

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -84,8 +84,8 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
           name: 'shadowbrook-api'
           image: '${containerRegistryLoginServer}/shadowbrook:${imageTag}'
           resources: {
-            cpu: json('1.0')
-            memory: '2Gi'
+            cpu: json('0.75')
+            memory: '1.5Gi'
           }
           env: [
             {
@@ -115,24 +115,6 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             {
               name: 'AzureAd__ManagedIdentityClientId'
               value: managedIdentityClientId
-            }
-            // GC tuning: keep heap within budget and return memory to OS aggressively.
-            // GCHeapHardLimit caps the managed heap at 512 MiB — keeps the heap compact
-            // while leaving ~1.5 GiB for native memory, thread stacks, and burst headroom.
-            // GCConserveMemory=9 (max) forces the most aggressive compaction/decommit.
-            // GCRetainVM=0 forces Server GC to decommit pages after collection instead of
-            // holding them — critical in containers where retained pages count toward the limit.
-            {
-              name: 'DOTNET_GCConserveMemory'
-              value: '9'
-            }
-            {
-              name: 'DOTNET_GCHeapHardLimit'
-              value: '536870912'
-            }
-            {
-              name: 'DOTNET_GCRetainVM'
-              value: '0'
             }
           ]
           probes: [

--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -1,10 +1,7 @@
 using Azure.Identity;
-using Azure.Monitor.OpenTelemetry.AspNetCore;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Graph;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
 using Serilog;
 using Shadowbrook.Api.Features.Dev;
 using Shadowbrook.Api.Infrastructure.Auth;
@@ -40,40 +37,36 @@ Log.Logger = new LoggerConfiguration()
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Remove default console provider so writeToProviders only forwards to App Insights, not a second console
 builder.Logging.ClearProviders();
 
-builder.Host.UseSerilog((context, services, configuration) => configuration
-    .ReadFrom.Configuration(context.Configuration)
-    .ReadFrom.Services(services)
-    .Enrich.FromLogContext()
-    .Enrich.WithMachineName()
-    .Enrich.WithEnvironmentName()
-    .Enrich.With(services.GetRequiredService<OrganizationIdEnricher>())
-    .WriteTo.Console(outputTemplate:
-        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"),
-    writeToProviders: true);
+var appInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
 builder.Services.AddSingleton<OrganizationIdEnricher>();
 
-var appInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
-if (!string.IsNullOrEmpty(appInsightsConnectionString))
+builder.Host.UseSerilog((context, services, configuration) =>
 {
-    builder.Services.AddOpenTelemetry()
-        .WithTracing(tracing => tracing
-            .AddAspNetCoreInstrumentation(o =>
-                o.Filter = context => context.Request.Path != "/health")
-            .AddHttpClientInstrumentation()
-            // EF Core instrumentation disabled — Wolverine's inbox/outbox polling generates
-            // ~232 dependency spans/min (~334K/day) with zero diagnostic value, consuming
-            // significant native memory in the OTEL pipeline that GC cannot reclaim.
-            .AddSource("Wolverine"))
-        .WithMetrics(metrics => metrics
-            .AddAspNetCoreInstrumentation()
-            .AddHttpClientInstrumentation())
-        .WithLogging()
-        .UseAzureMonitor(o => o.ConnectionString = appInsightsConnectionString);
-}
+    configuration
+        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext()
+        .Enrich.WithMachineName()
+        .Enrich.WithEnvironmentName()
+        .Enrich.With(services.GetRequiredService<OrganizationIdEnricher>())
+        .WriteTo.Console(outputTemplate:
+            "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+
+    // Serilog sink replaces the full OTEL pipeline (tracing, metrics, span processors).
+    // The OTEL SDK consumed ~670 MB of native memory from span/metric processing buffers
+    // that the GC could never reclaim. The Serilog sink uses a managed TelemetryClient
+    // instead, populating the App Insights traces and exceptions tables with structured
+    // properties (including OrganizationId) in customDimensions.
+    if (!string.IsNullOrEmpty(appInsightsConnectionString))
+    {
+        configuration.WriteTo.ApplicationInsights(
+            appInsightsConnectionString,
+            TelemetryConverter.Traces);
+    }
+});
 
 builder.Services.Configure<AppSettings>(builder.Configuration.GetSection("App"));
 

--- a/src/backend/Shadowbrook.Api/Shadowbrook.Api.csproj
+++ b/src/backend/Shadowbrook.Api/Shadowbrook.Api.csproj
@@ -38,10 +38,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Replace the full OpenTelemetry + Azure Monitor SDK with `Serilog.Sinks.ApplicationInsights` — eliminates ~670 MB of native memory that the GC could never reclaim
- Revert container resources to 0.75 CPU / 1.5 Gi (from 1.0 / 2 Gi emergency bump)
- Remove GC tuning env vars (GCHeapHardLimit, GCConserveMemory, GCRetainVM) that were compensating for OTEL memory pressure

## Context

Local diagnostics showed the app uses ~420 MB under heavy load without OTEL. Deployed with OTEL, it grew to ~1,090 MB and never recovered — the difference is entirely native memory from the OTEL span/metric processing pipeline.

The Serilog sink preserves structured log querying in App Insights (`traces` and `exceptions` tables with `customDimensions` including `OrganizationId`). We lose the `requests` and `dependencies` tables (HTTP metrics, distributed tracing) which can be replicated with targeted logging if needed.

## Test plan

- [x] Unit tests pass (206 API + 131 domain)
- [x] Build succeeds
- [ ] Deploy to test env and verify App Insights receives structured logs
- [ ] Monitor memory — should stay under 500 MB under load
- [ ] Verify KQL queries against `traces` table still return structured data

🤖 Generated with [Claude Code](https://claude.com/claude-code)