### PR TITLE
fix: gracefully ignore late-arriving messages on completed waitlist policies

### DIFF
--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicy.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicy.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Api.Infrastructure.Services;
 using Shadowbrook.Domain.Common;
@@ -44,6 +45,24 @@ public class TeeTimeOpeningExpirationPolicy : Saga
 
     public void Handle(
         [SagaIdentityFrom("OpeningId")] TeeTimeOpeningCancelled evt) => MarkCompleted();
+
+    public static void NotFound(TeeTimeOpeningExpirationTimeout timeout, ILogger<TeeTimeOpeningExpirationPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {MessageType} for {Id}", nameof(TeeTimeOpeningExpirationTimeout), timeout.Id);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningFilled evt,
+        ILogger<TeeTimeOpeningExpirationPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningFilled), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningExpired evt,
+        ILogger<TeeTimeOpeningExpirationPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningExpired), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningCancelled evt,
+        ILogger<TeeTimeOpeningExpirationPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningCancelled), evt.OpeningId);
 }
 
 public record TeeTimeOpeningExpirationTimeout(Guid Id, TimeSpan Delay) : TimeoutMessage(Delay);

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningOfferPolicy.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/TeeTimeOpeningOfferPolicy.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
@@ -65,6 +66,49 @@ public class TeeTimeOpeningOfferPolicy : Saga
     public void Handle([SagaIdentityFrom("OpeningId")] TeeTimeOpeningExpired evt) => MarkCompleted();
 
     public FindAndOfferEligibleGolfers? Handle([SagaIdentityFrom("OpeningId")] WakeUpOfferPolicy command) => DispatchMoreOffersIfNeeded();
+
+    public static void NotFound(OfferDispatchGracePeriodTimeout timeout, ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {MessageType} for {Id}", nameof(OfferDispatchGracePeriodTimeout), timeout.Id);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningCancelled evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningCancelled), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] WaitlistOfferAccepted evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(WaitlistOfferAccepted), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningSlotsClaimed evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningSlotsClaimed), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] WaitlistOfferRejected evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(WaitlistOfferRejected), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] WaitlistOfferStale evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(WaitlistOfferStale), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningFilled evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningFilled), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] TeeTimeOpeningExpired evt,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for opening {OpeningId}", nameof(TeeTimeOpeningExpired), evt.OpeningId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("OpeningId")] WakeUpOfferPolicy command,
+        ILogger<TeeTimeOpeningOfferPolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {CommandType} for {OpeningId}", nameof(WakeUpOfferPolicy), command.OpeningId);
 
     private FindAndOfferEligibleGolfers? DispatchMoreOffersIfNeeded()
     {

--- a/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/WaitlistOfferResponsePolicy.cs
+++ b/src/backend/Shadowbrook.Api/Features/Waitlist/Policies/WaitlistOfferResponsePolicy.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
 using Wolverine;
@@ -38,6 +39,19 @@ public class WaitlistOfferResponsePolicy : Saga
 
     public void Handle(
         [SagaIdentityFrom("WaitlistOfferId")] WaitlistOfferRejected evt) => MarkCompleted();
+
+    public static void NotFound(OfferResponseBufferTimeout timeout, ILogger<WaitlistOfferResponsePolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {MessageType} for {Id}", nameof(OfferResponseBufferTimeout), timeout.Id);
+
+    public static void NotFound(
+        [SagaIdentityFrom("WaitlistOfferId")] WaitlistOfferAccepted evt,
+        ILogger<WaitlistOfferResponsePolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for offer {WaitlistOfferId}", nameof(WaitlistOfferAccepted), evt.WaitlistOfferId);
+
+    public static void NotFound(
+        [SagaIdentityFrom("WaitlistOfferId")] WaitlistOfferRejected evt,
+        ILogger<WaitlistOfferResponsePolicy> logger) =>
+        logger.LogInformation("Policy already completed, ignoring {EventType} for offer {WaitlistOfferId}", nameof(WaitlistOfferRejected), evt.WaitlistOfferId);
 }
 
 public record OfferResponseBufferTimeout(Guid Id, TimeSpan Buffer) : TimeoutMessage(Buffer);

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicyTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningExpirationPolicyTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
@@ -91,5 +92,47 @@ public class TeeTimeOpeningExpirationPolicyTests
         policy.Handle(evt);
 
         Assert.True(policy.IsCompleted());
+    }
+
+    [Fact]
+    public void NotFound_ExpirationTimeout_DoesNotThrow()
+    {
+        var timeout = new TeeTimeOpeningExpirationTimeout(Guid.NewGuid(), TimeSpan.FromMinutes(5));
+        var logger = NullLogger<TeeTimeOpeningExpirationPolicy>.Instance;
+
+        TeeTimeOpeningExpirationPolicy.NotFound(timeout, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningFilled_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningFilled { OpeningId = Guid.NewGuid() };
+        var logger = NullLogger<TeeTimeOpeningExpirationPolicy>.Instance;
+
+        TeeTimeOpeningExpirationPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningExpired_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningExpired { OpeningId = Guid.NewGuid() };
+        var logger = NullLogger<TeeTimeOpeningExpirationPolicy>.Instance;
+
+        TeeTimeOpeningExpirationPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningCancelled_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningCancelled
+        {
+            OpeningId = Guid.NewGuid(),
+            CourseId = Guid.NewGuid(),
+            Date = new DateOnly(2026, 3, 25),
+            TeeTime = new TimeOnly(14, 30)
+        };
+        var logger = NullLogger<TeeTimeOpeningExpirationPolicy>.Instance;
+
+        TeeTimeOpeningExpirationPolicy.NotFound(evt, logger);
     }
 }

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningOfferPolicyTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/TeeTimeOpeningOfferPolicyTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.TeeTimeOpeningAggregate.Events;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
@@ -212,5 +213,122 @@ public class TeeTimeOpeningOfferPolicyTests
         var result = policy.Handle(new WakeUpOfferPolicy(openingId));
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void NotFound_OfferDispatchGracePeriodTimeout_DoesNotThrow()
+    {
+        var timeout = new OfferDispatchGracePeriodTimeout(Guid.NewGuid(), TimeSpan.FromMinutes(5));
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(timeout, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningCancelled_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningCancelled
+        {
+            OpeningId = Guid.NewGuid(),
+            CourseId = Guid.NewGuid(),
+            Date = new DateOnly(2026, 3, 25),
+            TeeTime = new TimeOnly(14, 30)
+        };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_WaitlistOfferAccepted_DoesNotThrow()
+    {
+        var evt = new WaitlistOfferAccepted
+        {
+            WaitlistOfferId = Guid.NewGuid(),
+            BookingId = Guid.NewGuid(),
+            OpeningId = Guid.NewGuid(),
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            GolferId = Guid.NewGuid(),
+            GroupSize = 1,
+            CourseId = Guid.NewGuid(),
+            Date = new DateOnly(2026, 3, 25),
+            TeeTime = new TimeOnly(14, 30)
+        };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningSlotsClaimed_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningSlotsClaimed
+        {
+            OpeningId = Guid.NewGuid(),
+            BookingId = Guid.NewGuid(),
+            GolferId = Guid.NewGuid(),
+            CourseId = Guid.NewGuid(),
+            Date = new DateOnly(2026, 3, 25),
+            TeeTime = new TimeOnly(14, 30),
+            GroupSize = 1
+        };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_WaitlistOfferRejected_DoesNotThrow()
+    {
+        var evt = new WaitlistOfferRejected
+        {
+            WaitlistOfferId = Guid.NewGuid(),
+            OpeningId = Guid.NewGuid(),
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            Reason = "Declined"
+        };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_WaitlistOfferStale_DoesNotThrow()
+    {
+        var evt = new WaitlistOfferStale
+        {
+            WaitlistOfferId = Guid.NewGuid(),
+            OpeningId = Guid.NewGuid()
+        };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningFilled_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningFilled { OpeningId = Guid.NewGuid() };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_TeeTimeOpeningExpired_DoesNotThrow()
+    {
+        var evt = new TeeTimeOpeningExpired { OpeningId = Guid.NewGuid() };
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_WakeUpOfferPolicy_DoesNotThrow()
+    {
+        var command = new WakeUpOfferPolicy(Guid.NewGuid());
+        var logger = NullLogger<TeeTimeOpeningOfferPolicy>.Instance;
+
+        TeeTimeOpeningOfferPolicy.NotFound(command, logger);
     }
 }

--- a/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/WaitlistOfferResponsePolicyTests.cs
+++ b/tests/Shadowbrook.Api.Tests/Features/Waitlist/Policies/WaitlistOfferResponsePolicyTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using Shadowbrook.Api.Features.Waitlist.Handlers;
 using Shadowbrook.Api.Features.Waitlist.Policies;
 using Shadowbrook.Domain.WaitlistOfferAggregate.Events;
@@ -96,5 +97,49 @@ public class WaitlistOfferResponsePolicyTests
         });
 
         Assert.True(policy.IsCompleted());
+    }
+
+    [Fact]
+    public void NotFound_OfferResponseBufferTimeout_DoesNotThrow()
+    {
+        var timeout = new OfferResponseBufferTimeout(Guid.NewGuid(), TimeSpan.FromMinutes(5));
+        var logger = NullLogger<WaitlistOfferResponsePolicy>.Instance;
+
+        WaitlistOfferResponsePolicy.NotFound(timeout, logger);
+    }
+
+    [Fact]
+    public void NotFound_WaitlistOfferAccepted_DoesNotThrow()
+    {
+        var evt = new WaitlistOfferAccepted
+        {
+            WaitlistOfferId = Guid.NewGuid(),
+            BookingId = Guid.NewGuid(),
+            OpeningId = Guid.NewGuid(),
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            GolferId = Guid.NewGuid(),
+            GroupSize = 1,
+            CourseId = Guid.NewGuid(),
+            Date = new DateOnly(2026, 3, 25),
+            TeeTime = new TimeOnly(14, 30)
+        };
+        var logger = NullLogger<WaitlistOfferResponsePolicy>.Instance;
+
+        WaitlistOfferResponsePolicy.NotFound(evt, logger);
+    }
+
+    [Fact]
+    public void NotFound_WaitlistOfferRejected_DoesNotThrow()
+    {
+        var evt = new WaitlistOfferRejected
+        {
+            WaitlistOfferId = Guid.NewGuid(),
+            OpeningId = Guid.NewGuid(),
+            GolferWaitlistEntryId = Guid.NewGuid(),
+            Reason = "Declined"
+        };
+        var logger = NullLogger<WaitlistOfferResponsePolicy>.Instance;
+
+        WaitlistOfferResponsePolicy.NotFound(evt, logger);
     }
 }


### PR DESCRIPTION
## Summary

- Adds static `NotFound` methods to `TeeTimeOpeningExpirationPolicy`, `TeeTimeOpeningOfferPolicy`, and `WaitlistOfferResponsePolicy`
- Covers 16 message types total (4 + 9 + 3) — timeouts, domain events, and commands
- Replaces `UnknownSagaException` + dead-letter with a structured `LogInformation` entry when messages arrive after `MarkCompleted()` has been called

## Test plan

- [ ] All 39 policy unit tests pass (`dotnet test --filter "FullyQualifiedName~Policies"`)
- [ ] Each `NotFound` overload has a corresponding `NotFound_*_DoesNotThrow` unit test
- [ ] Build is clean with no IDE0022 style warnings

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)