### PR TITLE
fix: rewrite e2e auth for dev auth mode + repeatable test runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       ASPNETCORE_ENVIRONMENT: "Development"
       ConnectionStrings__DefaultConnection: "Server=db;Database=Shadowbrook;User Id=sa;Password=Dev@Password123!;TrustServerCertificate=True"
       Cors__AllowedOrigins__0: "http://localhost:3000"
+      Auth__UseDevAuth: "true"
     volumes:
       - ./src/backend:/app
       - api_obj:/app/Shadowbrook.Api/obj

--- a/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
+++ b/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using Shadowbrook.Domain.AppUserAggregate;
 using Shadowbrook.Domain.CourseAggregate;
 using Shadowbrook.Domain.OrganizationAggregate;
+using Shadowbrook.Domain.Services;
 using Shadowbrook.Domain.TenantAggregate;
 
 namespace Shadowbrook.Api.Infrastructure.Data;
@@ -42,6 +44,8 @@ public static class E2ESeedData
         await EnsureCourseAsync(db, organization.Id, "Pine Valley Test", "America/New_York");
         await EnsureCourseAsync(db, organization.Id, "Augusta Test", "America/New_York");
         await EnsureCourseAsync(db, organization.Id, "Pebble Beach Test", "America/Los_Angeles");
+
+        await EnsureAppUsersAsync(db, organization.Id);
     }
 
     private static async Task EnsureCourseAsync(
@@ -62,5 +66,41 @@ public static class E2ESeedData
         var course = Course.Create(organizationId, name, timeZoneId);
         db.Courses.Add(course);
         await db.SaveChangesAsync();
+    }
+
+    private static async Task EnsureAppUsersAsync(ApplicationDbContext db, Guid organizationId)
+    {
+        var emailChecker = new SeedEmailChecker(db);
+
+        var adminExists = await db.AppUsers
+            .AnyAsync(u => u.IdentityId == "e2e-admin-oid");
+
+        if (!adminExists)
+        {
+            var admin = await AppUser.CreateAdmin("e2e-admin@shadowbrook.golf", emailChecker);
+            admin.CompleteIdentitySetup("e2e-admin-oid", "E2E", "Admin");
+            db.AppUsers.Add(admin);
+            await db.SaveChangesAsync();
+        }
+
+        var operatorExists = await db.AppUsers
+            .AnyAsync(u => u.IdentityId == "e2e-operator-oid");
+
+        if (!operatorExists)
+        {
+            var operatorUser = await AppUser.CreateOperator(
+                "e2e-operator@shadowbrook.golf",
+                organizationId,
+                emailChecker);
+            operatorUser.CompleteIdentitySetup("e2e-operator-oid", "E2E", "Operator");
+            db.AppUsers.Add(operatorUser);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    private sealed class SeedEmailChecker(ApplicationDbContext db) : IAppUserEmailUniquenessChecker
+    {
+        public async Task<bool> IsEmailInUse(string email, CancellationToken ct = default) =>
+            await db.AppUsers.AnyAsync(u => u.Email == email, ct);
     }
 }

--- a/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
+++ b/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
@@ -78,7 +78,7 @@ public static class E2ESeedData
 
         if (!adminExists)
         {
-            var admin = await AppUser.CreateAdmin("e2e-admin@shadowbrook.golf", emailChecker);
+            var admin = await AppUser.CreateAdmin("e2e-admin@benjamingolfco.onmicrosoft.com", emailChecker);
             admin.CompleteIdentitySetup("e2e-admin-oid", "E2E", "Admin");
             db.AppUsers.Add(admin);
             await db.SaveChangesAsync();

--- a/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
+++ b/src/backend/Shadowbrook.Api/Infrastructure/Data/E2ESeedData.cs
@@ -44,6 +44,7 @@ public static class E2ESeedData
         await EnsureCourseAsync(db, organization.Id, "Pine Valley Test", "America/New_York");
         await EnsureCourseAsync(db, organization.Id, "Augusta Test", "America/New_York");
         await EnsureCourseAsync(db, organization.Id, "Pebble Beach Test", "America/Los_Angeles");
+        await EnsureCourseAsync(db, organization.Id, "E2E Walkup Course", "Etc/UTC");
 
         await EnsureAppUsersAsync(db, organization.Id);
     }

--- a/src/backend/Shadowbrook.Api/Program.cs
+++ b/src/backend/Shadowbrook.Api/Program.cs
@@ -166,14 +166,16 @@ if (!app.Environment.IsProduction() && app.Environment.EnvironmentName != "Testi
 app.UseSerilogRequestLogging();
 app.UseDomainExceptionHandler();
 
-var cspAuthDomain = new Uri(builder.Configuration["AzureAd:Instance"]!).Host;
+var azureAdInstance = builder.Configuration["AzureAd:Instance"];
+var cspAuthDirectives = !string.IsNullOrEmpty(azureAdInstance)
+    ? $"connect-src 'self' https://{new Uri(azureAdInstance).Host}; frame-src https://{new Uri(azureAdInstance).Host};"
+    : "connect-src 'self';";
 app.Use(async (context, next) =>
 {
     context.Response.Headers.Append(
         "Content-Security-Policy",
         $"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
-        + $"img-src 'self' data:; connect-src 'self' https://{cspAuthDomain}; "
-        + $"frame-src https://{cspAuthDomain};");
+        + $"img-src 'self' data:; {cspAuthDirectives}");
     await next();
 });
 

--- a/src/web/.env.e2e
+++ b/src/web/.env.e2e
@@ -1,0 +1,4 @@
+# E2E test environment — dev auth enabled, no MSAL redirects
+VITE_USE_DEV_AUTH=true
+VITE_DEV_IDENTITY_ID=e2e-admin-oid
+VITE_SHOW_DEV_TOOLS=true

--- a/src/web/e2e/fixtures/auth.ts
+++ b/src/web/e2e/fixtures/auth.ts
@@ -90,9 +90,9 @@ async function setRole(page: Page, role: 'admin' | 'operator', identityId: strin
 
   // Wait for the app to finish loading and redirect based on role
   if (role === 'admin') {
-    await page.waitForURL('**/admin/**');
+    await page.waitForURL('**/admin*');
   } else {
-    await page.waitForURL('**/operator/**');
+    await page.waitForURL('**/operator*');
   }
 }
 

--- a/src/web/e2e/fixtures/auth.ts
+++ b/src/web/e2e/fixtures/auth.ts
@@ -1,16 +1,99 @@
 import { test as base, type Page } from '@playwright/test';
+import { API_BASE_URL } from '../playwright.config';
 
 /**
- * Auth fixture that abstracts authentication.
- * Currently uses the dev role switcher.
- * When real auth lands, swap the internals without changing test files.
+ * Auth fixture that provides role switching for e2e tests.
+ *
+ * Uses page.route() to intercept GET /auth/me and return the real user payload
+ * for the requested role. Also swaps the Authorization Bearer token on all
+ * API requests so the backend resolves the correct AppUser (with correct
+ * OrganizationId and permissions).
+ *
+ * Requires:
+ * - Frontend running with VITE_USE_DEV_AUTH=true (--mode e2e)
+ * - Backend running with Auth:UseDevAuth=true
+ * - E2E seed data with AppUsers for e2e-admin-oid and e2e-operator-oid
  */
 
-async function setRole(page: Page, role: 'golfer' | 'operator' | 'admin') {
-  // Must navigate to the app first so localStorage is accessible (not about:blank).
+interface MePayload {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  displayName: string;
+  role: string;
+  organization: { id: string; name: string } | null;
+  organizations: { id: string; name: string }[] | null;
+  courses: { id: string; name: string }[];
+  permissions: string[];
+}
+
+/**
+ * Fetch the real /auth/me response for a given identity and cache it.
+ * This ensures mock payloads have real IDs from the seeded database.
+ */
+const meCache = new Map<string, MePayload>();
+
+async function fetchRealMe(identityId: string): Promise<MePayload> {
+  const cached = meCache.get(identityId);
+  if (cached) return cached;
+
+  const response = await fetch(`${API_BASE_URL}/auth/me`, {
+    headers: { Authorization: `Bearer ${identityId}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch /auth/me for identity "${identityId}": ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as MePayload;
+  meCache.set(identityId, data);
+  return data;
+}
+
+async function setRole(page: Page, role: 'admin' | 'operator', identityId: string) {
+  // Fetch the real user data from the API (seeded in E2ESeedData)
+  const mePayload = await fetchRealMe(identityId);
+
+  // Remove any previous route handlers (from prior role switches in serial tests)
+  await page.unrouteAll({ behavior: 'ignoreErrors' });
+
+  // Intercept /auth/me to return the correct user
+  await page.route('**/auth/me', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mePayload),
+    });
+  });
+
+  // Intercept all API requests to swap the Bearer token for this role's identity.
+  // The API client sends `Authorization: Bearer <VITE_DEV_IDENTITY_ID>` by default,
+  // but we need the correct identity per role so the backend resolves the right
+  // AppUser (with correct OrganizationId and permissions).
+  await page.route('**/*', (route, request) => {
+    const headers = request.headers();
+    if (
+      (request.resourceType() === 'fetch' || request.resourceType() === 'xhr') &&
+      headers['authorization']
+    ) {
+      headers['authorization'] = `Bearer ${identityId}`;
+      return route.continue({ headers });
+    }
+    return route.continue();
+  });
+
+  // Navigate to the app — DevAuthProvider will call /auth/me and get our mock
   await page.goto('/');
-  await page.evaluate((r) => localStorage.setItem('shadowbrook-dev-role', r), role);
-  await page.reload();
+
+  // Wait for the app to finish loading and redirect based on role
+  if (role === 'admin') {
+    await page.waitForURL('**/admin/**');
+  } else {
+    await page.waitForURL('**/operator/**');
+  }
 }
 
 export const test = base.extend<{
@@ -20,17 +103,18 @@ export const test = base.extend<{
 }>({
   asGolfer: async ({ page }, use) => {
     await use(async () => {
-      await setRole(page, 'golfer');
+      // Golfer routes are public — no auth needed
+      await page.goto('/join');
     });
   },
   asOperator: async ({ page }, use) => {
     await use(async () => {
-      await setRole(page, 'operator');
+      await setRole(page, 'operator', 'e2e-operator-oid');
     });
   },
   asAdmin: async ({ page }, use) => {
     await use(async () => {
-      await setRole(page, 'admin');
+      await setRole(page, 'admin', 'e2e-admin-oid');
     });
   },
 });

--- a/src/web/e2e/fixtures/operator-waitlist-page.ts
+++ b/src/web/e2e/fixtures/operator-waitlist-page.ts
@@ -8,11 +8,7 @@ export class OperatorWaitlistPage {
   }
 
   async goto() {
-    await this.page.goto('/operator/waitlist');
-  }
-
-  async selectTenant(tenantName: string) {
-    await this.page.getByRole('cell', { name: tenantName }).click();
+    await this.page.goto('/operator');
   }
 
   async selectCourse(courseName: string) {

--- a/src/web/e2e/fixtures/operator-waitlist-page.ts
+++ b/src/web/e2e/fixtures/operator-waitlist-page.ts
@@ -18,23 +18,48 @@ export class OperatorWaitlistPage {
     await this.page.getByRole('heading', { name: 'Walk-Up Waitlist' }).waitFor();
   }
 
-  async openWaitlist() {
-    await this.openWaitlistButton.click();
-
-    // No confirmation dialog — button directly fires the mutation.
-    // Wait for either the short code (success) or an error message (API failure).
+  /**
+   * Ensure a fresh waitlist is open for today.
+   * Handles three possible states:
+   * - No waitlist → click "Open Waitlist for Today"
+   * - Already open → close it, then reopen
+   * - Closed → reopen it
+   */
+  async ensureFreshWaitlist() {
+    const openButton = this.openWaitlistButton;
     const shortCode = this.page.getByTestId('short-code');
-    const error = this.page.getByRole('alert');
+    const closedBadge = this.page.getByText('Closed', { exact: true });
 
-    const result = await Promise.race([
-      shortCode.waitFor().then(() => 'success' as const),
-      error.waitFor().then(() => 'error' as const),
+    // Wait for the page to settle into one of three states
+    const state = await Promise.race([
+      openButton.waitFor().then(() => 'no-waitlist' as const),
+      shortCode.waitFor().then(() => 'open' as const),
+      closedBadge.waitFor().then(() => 'closed' as const),
     ]);
 
-    if (result === 'error') {
-      const msg = await error.textContent();
-      throw new Error(`Open waitlist failed: ${msg}`);
+    if (state === 'open') {
+      // Close the existing waitlist first
+      await this.page.getByText('Close waitlist for today').click();
+      const closeDialog = this.page.getByRole('alertdialog');
+      await closeDialog.waitFor();
+      await closeDialog.getByRole('button', { name: 'Close Waitlist' }).click();
+      // Wait for closed state
+      await closedBadge.waitFor();
     }
+
+    if (state === 'open' || state === 'closed') {
+      // Reopen from closed state
+      await this.page.getByRole('button', { name: 'Reopen' }).click();
+      const reopenDialog = this.page.getByRole('alertdialog');
+      await reopenDialog.waitFor();
+      await reopenDialog.getByRole('button', { name: 'Reopen Waitlist' }).click();
+    } else {
+      // No waitlist yet — open fresh
+      await openButton.click();
+    }
+
+    // Wait for the short code to appear (confirms waitlist is open)
+    await shortCode.waitFor();
   }
 
   async getShortCode(): Promise<string> {
@@ -61,10 +86,5 @@ export class OperatorWaitlistPage {
 
     // Wait for success feedback
     await this.page.getByRole('button', { name: 'Posted!' }).waitFor();
-  }
-
-  /** Openings are now rendered inline — no tab to select. This is a no-op for backward compat. */
-  async selectOpeningsTab() {
-    // Openings list is always visible on the active waitlist page — no tab needed.
   }
 }

--- a/src/web/e2e/fixtures/sms-helper.ts
+++ b/src/web/e2e/fixtures/sms-helper.ts
@@ -25,7 +25,8 @@ export async function waitForSms(
 
     if (response.ok) {
       const messages: DevSmsMessage[] = await response.json();
-      const match = messages.find((m) => predicate(m.body));
+      // Use findLast to get the most recent match — avoids stale SMS from prior runs
+      const match = messages.findLast((m) => predicate(m.body));
       if (match) {
         return match.body;
       }

--- a/src/web/e2e/fixtures/test-data.ts
+++ b/src/web/e2e/fixtures/test-data.ts
@@ -11,6 +11,10 @@ export const TEST_GOLFER = {
   normalizedPhone: '+15551230000',
 };
 
+/** Identity IDs matching AppUsers seeded in E2ESeedData.cs */
+export const TEST_ADMIN_IDENTITY_ID = 'e2e-admin-oid';
+export const TEST_OPERATOR_IDENTITY_ID = 'e2e-operator-oid';
+
 /**
  * Generate a unique course name per test run to avoid stale state.
  */

--- a/src/web/e2e/fixtures/test-data.ts
+++ b/src/web/e2e/fixtures/test-data.ts
@@ -3,21 +3,18 @@
  * Must match E2ESeedData.cs in the backend.
  */
 export const TEST_TENANT_NAME = 'E2E Test Golf Group';
+
+/** Dedicated e2e course seeded with UTC timezone to avoid timezone mismatches. */
+export const TEST_E2E_COURSE = 'E2E Walkup Course';
+
+/** Dedicated e2e golfer — unique phone number to avoid SMS collisions. */
 export const TEST_GOLFER = {
   firstName: 'E2E',
   lastName: 'Tester',
-  phone: '5551230000',
-  /** Phone in E.164 format as stored by the backend (for dev SMS API lookups) */
-  normalizedPhone: '+15551230000',
+  phone: '5559990001',
+  normalizedPhone: '+15559990001',
 };
 
 /** Identity IDs matching AppUsers seeded in E2ESeedData.cs */
 export const TEST_ADMIN_IDENTITY_ID = 'e2e-admin-oid';
 export const TEST_OPERATOR_IDENTITY_ID = 'e2e-operator-oid';
-
-/**
- * Generate a unique course name per test run to avoid stale state.
- */
-export function uniqueCourseName(): string {
-  return `E2E Run ${Date.now()}`;
-}

--- a/src/web/e2e/playwright.config.ts
+++ b/src/web/e2e/playwright.config.ts
@@ -21,4 +21,13 @@ export default defineConfig({
       use: { browserName: 'chromium' },
     },
   ],
+  ...(!process.env.CI && !process.env.E2E_BASE_URL
+    ? {
+        webServer: {
+          command: 'pnpm dev --mode e2e',
+          url: 'http://localhost:3000',
+          reuseExistingServer: true,
+        },
+      }
+    : {}),
 });

--- a/src/web/e2e/tests/walkup/walkup-flow.spec.ts
+++ b/src/web/e2e/tests/walkup/walkup-flow.spec.ts
@@ -3,7 +3,7 @@ import { OperatorWaitlistPage } from '../../fixtures/operator-waitlist-page';
 import { WalkupPage } from '../../fixtures/walkup-page';
 import { WalkUpOfferPage } from '../../fixtures/walk-up-offer-page';
 import { waitForSms, extractOfferUrl } from '../../fixtures/sms-helper';
-import { TEST_GOLFER, TEST_OPERATOR_IDENTITY_ID } from '../../fixtures/test-data';
+import { TEST_GOLFER, TEST_ADMIN_IDENTITY_ID } from '../../fixtures/test-data';
 import { API_BASE_URL } from '../../playwright.config';
 
 // Create a fresh course per run via API to avoid stale waitlist state
@@ -13,11 +13,19 @@ let offerPath: string;
 
 test.describe.serial('Walkup Waitlist Flow', () => {
   test('setup: create a fresh course', async () => {
+    // Get the E2E org ID from the admin's profile
+    const meResponse = await fetch(`${API_BASE_URL}/auth/me`, {
+      headers: { Authorization: `Bearer ${TEST_ADMIN_IDENTITY_ID}` },
+    });
+    const me = await meResponse.json();
+    const orgId = me.organizations[0].id;
+
     const response = await fetch(`${API_BASE_URL}/courses`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${TEST_OPERATOR_IDENTITY_ID}`,
+        Authorization: `Bearer ${TEST_ADMIN_IDENTITY_ID}`,
+        'X-Organization-Id': orgId,
       },
       body: JSON.stringify({ name: courseName, timeZoneId: 'Etc/UTC' }),
     });

--- a/src/web/e2e/tests/walkup/walkup-flow.spec.ts
+++ b/src/web/e2e/tests/walkup/walkup-flow.spec.ts
@@ -24,7 +24,6 @@ test.describe.serial('Walkup Waitlist Flow', () => {
     const waitlist = new OperatorWaitlistPage(page);
 
     await waitlist.goto();
-    await waitlist.selectTenant(TEST_TENANT_NAME);
     await waitlist.selectCourse(courseName);
     await waitlist.openWaitlist();
 
@@ -54,7 +53,6 @@ test.describe.serial('Walkup Waitlist Flow', () => {
     const waitlist = new OperatorWaitlistPage(page);
 
     await waitlist.goto();
-    await waitlist.selectTenant(TEST_TENANT_NAME);
     await waitlist.selectCourse(courseName);
 
     // Use a time 10 minutes from now — within the golfer's 30-minute walkup window

--- a/src/web/e2e/tests/walkup/walkup-flow.spec.ts
+++ b/src/web/e2e/tests/walkup/walkup-flow.spec.ts
@@ -1,22 +1,28 @@
 import { test, expect } from '../../fixtures/auth';
-import { AdminRegisterPage } from '../../fixtures/admin-register-page';
 import { OperatorWaitlistPage } from '../../fixtures/operator-waitlist-page';
 import { WalkupPage } from '../../fixtures/walkup-page';
 import { WalkUpOfferPage } from '../../fixtures/walk-up-offer-page';
 import { waitForSms, extractOfferUrl } from '../../fixtures/sms-helper';
-import { TEST_TENANT_NAME, TEST_GOLFER, uniqueCourseName } from '../../fixtures/test-data';
+import { TEST_GOLFER, TEST_OPERATOR_IDENTITY_ID } from '../../fixtures/test-data';
+import { API_BASE_URL } from '../../playwright.config';
 
-const courseName = uniqueCourseName();
+// Create a fresh course per run via API to avoid stale waitlist state
+const courseName = `E2E Run ${Date.now()}`;
 let walkupCode: string;
 let offerPath: string;
 
 test.describe.serial('Walkup Waitlist Flow', () => {
-  test('admin registers a new course', async ({ page, asAdmin }) => {
-    await asAdmin();
-    const register = new AdminRegisterPage(page);
+  test('setup: create a fresh course', async () => {
+    const response = await fetch(`${API_BASE_URL}/courses`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${TEST_OPERATOR_IDENTITY_ID}`,
+      },
+      body: JSON.stringify({ name: courseName, timeZoneId: 'Etc/UTC' }),
+    });
 
-    await register.goto();
-    await register.registerCourse(courseName, TEST_TENANT_NAME);
+    expect(response.status).toBe(201);
   });
 
   test('operator opens a walkup waitlist', async ({ page, asOperator }) => {
@@ -25,7 +31,7 @@ test.describe.serial('Walkup Waitlist Flow', () => {
 
     await waitlist.goto();
     await waitlist.selectCourse(courseName);
-    await waitlist.openWaitlist();
+    await waitlist.ensureFreshWaitlist();
 
     walkupCode = await waitlist.getShortCode();
     expect(walkupCode).toBeTruthy();
@@ -43,9 +49,8 @@ test.describe.serial('Walkup Waitlist Flow', () => {
 
     await walkup.fillJoinForm(TEST_GOLFER);
 
-    // Should see confirmation with position
+    // Should see confirmation
     await expect(walkup.getConfirmationHeading()).toBeVisible();
-    await expect(walkup.getPositionText()).toBeVisible();
   });
 
   test('operator adds a tee time opening', async ({ page, asOperator }) => {
@@ -55,11 +60,10 @@ test.describe.serial('Walkup Waitlist Flow', () => {
     await waitlist.goto();
     await waitlist.selectCourse(courseName);
 
-    // Use a time 10 minutes from now — within the golfer's 30-minute walkup window
-    // and past the 5-minute grace period for future-time validation.
-    // The course was registered with the browser's timezone, so local time works.
-    const futureTime = new Date(Date.now() + 10 * 60 * 1000);
-    const timeStr = `${String(futureTime.getHours()).padStart(2, '0')}:${String(futureTime.getMinutes()).padStart(2, '0')}`;
+    // Course uses UTC timezone. Compute tee time 10 minutes from now in UTC —
+    // within the 30-minute walkup window and past the 5-minute grace period.
+    const futureUtc = new Date(Date.now() + 10 * 60 * 1000);
+    const timeStr = `${String(futureUtc.getUTCHours()).padStart(2, '0')}:${String(futureUtc.getUTCMinutes()).padStart(2, '0')}`;
     await waitlist.addTeeTimeOpening(timeStr, 1);
 
     // Verify the opening appears in the list

--- a/tests/Shadowbrook.Api.IntegrationTests/TestWebApplicationFactory.cs
+++ b/tests/Shadowbrook.Api.IntegrationTests/TestWebApplicationFactory.cs
@@ -1,3 +1,4 @@
+using JasperFx.CommandLine;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.SqlClient;
@@ -24,6 +25,10 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
 
     public async Task InitializeAsync()
     {
+        // Required so that RunJasperFxCommands in Program.cs starts the host when
+        // running under WebApplicationFactory (instead of blocking on app.Run()).
+        JasperFxEnvironment.AutoStartHost = true;
+
         await this.sqlContainer.StartAsync();
         this.connectionString = this.sqlContainer.GetConnectionString();
     }

--- a/tests/Shadowbrook.Api.IntegrationTests/WalkUpWaitlistEndpointsTests.cs
+++ b/tests/Shadowbrook.Api.IntegrationTests/WalkUpWaitlistEndpointsTests.cs
@@ -487,7 +487,7 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
     {
         var (_, courseId) = await CreateTestCourseAsync();
 
-        var teeTime = DateTime.Today.AddHours(10);
+        var teeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
         var response = await PostCreateOpeningAsync(courseId, new { TeeTime = teeTime, SlotsAvailable = 4 });
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -502,7 +502,7 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
     public async Task CreateOpening_DuplicateTime_Returns409()
     {
         var (_, courseId) = await CreateTestCourseAsync();
-        var teeTime = DateTime.Today.AddHours(10);
+        var teeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
 
         var firstResponse = await PostCreateOpeningAsync(courseId, new { TeeTime = teeTime, SlotsAvailable = 4 });
         var firstBody = await firstResponse.Content.ReadFromJsonAsync<TeeTimeOpeningResponse>();
@@ -523,7 +523,7 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
     public async Task CreateOpening_DuplicateTime_PartialSlots_Returns409WithContext()
     {
         var (_, courseId) = await CreateTestCourseAsync();
-        var teeTime = DateTime.Today.AddHours(10);
+        var teeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
 
         var firstResponse = await PostCreateOpeningAsync(courseId, new { TeeTime = teeTime, SlotsAvailable = 2 });
         var firstBody = await firstResponse.Content.ReadFromJsonAsync<TeeTimeOpeningResponse>();
@@ -545,8 +545,8 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
     {
         var (_, courseId) = await CreateTestCourseAsync();
 
-        var r1 = await PostCreateOpeningAsync(courseId, new { TeeTime = DateTime.Today.AddHours(10), SlotsAvailable = 4 });
-        var r2 = await PostCreateOpeningAsync(courseId, new { TeeTime = DateTime.Today.AddHours(10).AddMinutes(30), SlotsAvailable = 4 });
+        var r1 = await PostCreateOpeningAsync(courseId, new { TeeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10), SlotsAvailable = 4 });
+        var r2 = await PostCreateOpeningAsync(courseId, new { TeeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10).AddMinutes(30), SlotsAvailable = 4 });
 
         Assert.Equal(HttpStatusCode.Created, r1.StatusCode);
         Assert.Equal(HttpStatusCode.Created, r2.StatusCode);
@@ -558,7 +558,7 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
         var (_, courseId1) = await CreateTestCourseAsync();
         var (_, courseId2) = await CreateTestCourseAsync();
 
-        var teeTime = DateTime.Today.AddHours(10);
+        var teeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
         var r1 = await PostCreateOpeningAsync(courseId1, new { TeeTime = teeTime, SlotsAvailable = 4 });
         var r2 = await PostCreateOpeningAsync(courseId2, new { TeeTime = teeTime, SlotsAvailable = 4 });
 
@@ -571,7 +571,7 @@ public class WalkUpWaitlistEndpointsTests(TestWebApplicationFactory factory) : I
     {
         var (_, courseId) = await CreateTestCourseAsync();
 
-        var teeTime = DateTime.Today.AddHours(10);
+        var teeTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
         var r1 = await PostCreateOpeningAsync(courseId, new { TeeTime = teeTime, SlotsAvailable = 4 });
         var body = await r1.Content.ReadFromJsonAsync<TeeTimeOpeningResponse>();
         await PostCancelOpeningAsync(courseId, body!.Id);


### PR DESCRIPTION
## Summary

- Rewrites e2e auth to use `DevAuthProvider` with `page.route()` interception instead of the dead `localStorage` approach that broke when real MSAL was enabled
- Creates fresh courses per test run via API to avoid stale waitlist state
- Seeds admin and operator AppUsers with known identity IDs for dev auth
- Enables dev auth in docker-compose for local e2e runs
- Uses Entra UPN for admin seed email so CI can auto-link the real Azure account

## Changes

**Backend:**
- Seed e2e admin (`e2e-admin@benjamingolfco.onmicrosoft.com`) and operator AppUsers with known IdentityIds
- Guard CSP config for missing `AzureAd:Instance` when using dev auth
- Add `Auth__UseDevAuth=true` to docker-compose
- Seed dedicated `E2E Walkup Course` with UTC timezone

**Frontend:**
- Add `.env.e2e` for Vite dev auth mode
- Add Playwright `webServer` config (starts Vite with `--mode e2e`)
- Rewrite auth fixture: `page.route('/auth/me')` + Bearer token swapping per role
- Remove admin course registration test (operator-only flow with API setup)
- Fix operator fixture for current UI (no tenant selection, direct course list)
- Use `findLast` for SMS matching to avoid stale message collisions

## Behavior changes

- **Removed position text assertion:** The golfer confirmation page no longer shows "#N in line at..." — it now shows "You're on the list, {name}!" without a position number. The `getPositionText()` assertion was removed from the spec to match the current UI. The method is kept in the page fixture in case position display returns.

## Test plan

- [x] All 6 e2e tests pass locally (3 consecutive runs verified)
- [ ] Deploy to test environment and verify e2e admin can log in
- [ ] Set up Playwright setup project for CI with real MSAL (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)