### PR TITLE
chore: update Azure URLs after teeforce infra redeployment

### DIFF
--- a/.claude/agent-memory/ux-designer/project_live_ux_review_march_2026.md
+++ b/.claude/agent-memory/ux-designer/project_live_ux_review_march_2026.md
@@ -1,6 +1,6 @@
 ---
 name: Live UX Review — March 2026
-description: Candid UX review of the live preview (white-stone-00610060f preview URL), covering all operator and admin pages as of late March 2026
+description: Candid UX review of the live preview (purple-field-0a3932a0f preview URL), covering all operator and admin pages as of late March 2026
 type: project
 ---
 

--- a/.claude/agents/stress-test-golfer.md
+++ b/.claude/agents/stress-test-golfer.md
@@ -25,8 +25,8 @@ The coordinator passes the following parameters:
 
 | Parameter | Description |
 |-----------|-------------|
-| `frontend_url` | Base URL of the Teeforce web app (e.g., `https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io`) |
-| `api_url` | Base URL of the Teeforce API (e.g., `https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io/api`) |
+| `frontend_url` | Base URL of the Teeforce web app (e.g., `https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io`) |
+| `api_url` | Base URL of the Teeforce API (e.g., `https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io/api`) |
 | `golfer_id` | Unique identifier for this golfer agent (e.g., `golfer-1`, `golfer-2`) |
 | `short_code` | 4-digit waitlist short code from the operator (e.g., `1308`) |
 | `feature_area` | Which feature area to exercise (e.g., `waitlist`) |

--- a/.claude/agents/stress-test-operator.md
+++ b/.claude/agents/stress-test-operator.md
@@ -25,7 +25,7 @@ The coordinator passes the following parameters:
 
 | Parameter | Description |
 |-----------|-------------|
-| `frontend_url` | Base URL of the frontend (e.g., `https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io`) |
+| `frontend_url` | Base URL of the frontend (e.g., `https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io`) |
 | `credentials` | Object with `upn` (user principal name) and `password` for Entra ID login |
 | `feature_area` | The area of the operator UI to exercise (e.g., `waitlist`) |
 | `role_brief` | Description of what operator actions to perform during this run |

--- a/.claude/skills/stress-test/SKILL.md
+++ b/.claude/skills/stress-test/SKILL.md
@@ -34,7 +34,7 @@ Orchestrate parallel AI agents (operator, golfers, observer) against a deployed 
 
 | Env | Frontend | API |
 |-----|----------|-----|
-| test | https://white-stone-00610060f.1.azurestaticapps.net | https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io |
+| test | https://purple-field-0a3932a0f.4.azurestaticapps.net | https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io |
 | local | http://localhost:3000 | http://localhost:5221 |
 
 **App Insights (test env):** app name `teeforce-insights-test`, resource group `teeforce-test-rg`

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  E2E_BASE_URL: https://white-stone-00610060f.1.azurestaticapps.net
-  E2E_API_URL: https://teeforce-app-test.placeholder.azurecontainerapps.io # TODO: Update after Azure redeployment
+  E2E_BASE_URL: https://purple-field-0a3932a0f.4.azurestaticapps.net
+  E2E_API_URL: https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io
 
 jobs:
   e2e:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Tee time booking platform for golf courses.
 
 ## Test Environment
 
-- **Frontend:** https://white-stone-00610060f.1.azurestaticapps.net
-- **API:** https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io
+- **Frontend:** https://purple-field-0a3932a0f.4.azurestaticapps.net
+- **API:** https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io
 
 ## Tech Stack
 

--- a/docs/qa/2026-04-04-walkup-waitlist-golfer-flow.md
+++ b/docs/qa/2026-04-04-walkup-waitlist-golfer-flow.md
@@ -1,6 +1,6 @@
 ## QA Report — Walk-Up Waitlist Golfer Flow (Manual Simulation)
 
-**Environment:** https://white-stone-00610060f.1.azurestaticapps.net / https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io
+**Environment:** https://purple-field-0a3932a0f.4.azurestaticapps.net / https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io
 **Date:** 2026-04-04
 **Result:** PARTIAL — Steps 1–4 verified; Steps 5–8 not reachable in this session (no operator-created opening)
 
@@ -68,7 +68,7 @@ The global SMS log contains successful end-to-end completions from earlier sessi
 | Time | Phone | Message |
 |------|-------|---------|
 | 2026-04-04T02:07:55 | +15075251450 | Joined waitlist confirmation |
-| 2026-04-04T02:08:29 | +15075251450 | Offer SMS: "Pine Valley Golf Course: 9:20 PM tee time available\! Claim your spot: https://white-stone-00610060f.1.azurestaticapps.net/book/walkup/019d563f-b5ee-77cd-b5ed-8c8fab27d6e3" |
+| 2026-04-04T02:08:29 | +15075251450 | Offer SMS: "Pine Valley Golf Course: 9:20 PM tee time available\! Claim your spot: https://purple-field-0a3932a0f.4.azurestaticapps.net/book/walkup/019d563f-b5ee-77cd-b5ed-8c8fab27d6e3" |
 | 2026-04-04T02:10:19 | +15075251450 | Confirmation: "Your tee time at Pine Valley Golf Course on April 3 at 9:20 PM is confirmed. See you on the course\!" |
 
 The offer token `019d563f-b5ee-77cd-b5ed-8c8fab27d6e3` resolves as `status: "Accepted"` from `GET /waitlist/offers/{token}`, confirming the claim was recorded. An earlier session (2026-04-03T19:43:57) also shows a rejection flow ("Sorry, that tee time is no longer available.") after an offer was superseded.

--- a/docs/qa/stress-test-2026-04-03-waitlist.md
+++ b/docs/qa/stress-test-2026-04-03-waitlist.md
@@ -1,7 +1,7 @@
 # Stress Test Report — waitlist — 2026-04-03
 
 **Duration:** ~8 minutes
-**Environment:** test (https://white-stone-00610060f.1.azurestaticapps.net)
+**Environment:** test (https://purple-field-0a3932a0f.4.azurestaticapps.net)
 **Agents:** 1 operator + 3 golfers + 1 observer
 **Hint:** none
 **Exit reason:** Circuit breaker — UnknownSagaException in TeeTimeOpeningExpirationPolicy handler

--- a/docs/qa/stress-test-2026-04-04-waitlist.md
+++ b/docs/qa/stress-test-2026-04-04-waitlist.md
@@ -1,7 +1,7 @@
 # Stress Test Report — waitlist — 2026-04-04
 
 **Duration:** 12 minutes  
-**Environment:** test (https://white-stone-00610060f.1.azurestaticapps.net)  
+**Environment:** test (https://purple-field-0a3932a0f.4.azurestaticapps.net)  
 **Agents:** 1 operator + 3 golfers + 1 observer  
 **Hint:** none  
 **Exit reason:** Circuit breaker — memory exceeded 1,000 MB  

--- a/docs/superpowers/plans/2026-04-03-stress-test-skill.md
+++ b/docs/superpowers/plans/2026-04-03-stress-test-skill.md
@@ -587,7 +587,7 @@ Launch parallel AI agents to exercise the Teeforce system with realistic concurr
 
 | Env | Frontend | API |
 |-----|----------|-----|
-| `test` | `https://white-stone-00610060f.1.azurestaticapps.net` | `https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io` |
+| `test` | `https://purple-field-0a3932a0f.4.azurestaticapps.net` | `https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io` |
 | `local` | `http://localhost:3000` | `http://localhost:5221` |
 
 App Insights (test env):

--- a/docs/superpowers/specs/2026-04-03-stress-test-skill-design.md
+++ b/docs/superpowers/specs/2026-04-03-stress-test-skill-design.md
@@ -28,7 +28,7 @@ A `/stress-test` skill that launches parallel AI agents to exercise the Teeforce
 
 | Env | Frontend | API |
 |-----|----------|-----|
-| `test` | `https://white-stone-00610060f.1.azurestaticapps.net` | `https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io` |
+| `test` | `https://purple-field-0a3932a0f.4.azurestaticapps.net` | `https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io` |
 | `local` | `http://localhost:3000` | `http://localhost:5221` |
 
 ## Agent Architecture

--- a/infra/README.md
+++ b/infra/README.md
@@ -273,7 +273,7 @@ az containerapp logs show \
   --follow
 
 # Check health endpoint
-curl https://teeforce-app-test.happypond-1a892999.eastus2.azurecontainerapps.io/health
+curl https://teeforce-app-test.wittywave-545ed3d5.eastus2.azurecontainerapps.io/health
 ```
 
 In the Azure Portal:


### PR DESCRIPTION
## Summary
- Updated container app URL from `happypond-1a892999` to `wittywave-545ed3d5` subdomain
- Updated SWA URL from `white-stone-00610060f.1` to `purple-field-0a3932a0f.4` subdomain
- Fixes E2E workflow API URL (was still a placeholder)

New URLs assigned after recreating Azure resources under teeforce naming.

## Test plan
- [ ] E2E workflow runs against correct URLs
- [ ] Stress test skill resolves correct endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)