### PR TITLE
chore: admin org page cleanup — soft-delete, shortcuts, Entra cleanup

### DIFF
--- a/src/backend/Teeforce.Api/Features/AppUsers/Handlers/AppUserDeleted/DeleteEntraUserHandler.cs
+++ b/src/backend/Teeforce.Api/Features/AppUsers/Handlers/AppUserDeleted/DeleteEntraUserHandler.cs
@@ -1,0 +1,22 @@
+using Teeforce.Domain.Services;
+using AppUserDeletedEvent = Teeforce.Domain.AppUserAggregate.Events.AppUserDeleted;
+
+namespace Teeforce.Api.Features.AppUsers.Handlers.AppUserDeleted;
+
+public static class DeleteEntraUserHandler
+{
+    public static async Task Handle(
+        AppUserDeletedEvent evt,
+        IAppUserDeletionService deletionService,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        if (evt.IdentityId is null)
+        {
+            logger.LogWarning("AppUser {AppUserId} has no IdentityId, skipping Entra deletion", evt.AppUserId);
+            return;
+        }
+
+        await deletionService.DeleteAsync(evt.IdentityId, ct);
+    }
+}

--- a/src/backend/Teeforce.Api/Features/Auth/AuthEndpoints.cs
+++ b/src/backend/Teeforce.Api/Features/Auth/AuthEndpoints.cs
@@ -225,6 +225,25 @@ public static class AuthEndpoints
         return Results.Ok(response);
     }
 
+    [WolverineDelete("/auth/users/{id}")]
+    [Authorize(Policy = AuthorizationPolicies.RequireUsersManage)]
+    public static async Task<IResult> DeleteUser(
+        Guid id,
+        [NotBody] ApplicationDbContext db)
+    {
+        var appUser = await db.AppUsers
+            .FirstOrDefaultAsync(u => u.Id == id);
+
+        if (appUser is null)
+        {
+            return Results.NotFound();
+        }
+
+        appUser.Delete();
+
+        return Results.NoContent();
+    }
+
 }
 
 public sealed record MeResponse(

--- a/src/backend/Teeforce.Api/Features/Auth/AuthEndpoints.cs
+++ b/src/backend/Teeforce.Api/Features/Auth/AuthEndpoints.cs
@@ -229,10 +229,11 @@ public static class AuthEndpoints
     [Authorize(Policy = AuthorizationPolicies.RequireUsersManage)]
     public static async Task<IResult> DeleteUser(
         Guid id,
-        [NotBody] ApplicationDbContext db)
+        [NotBody] ApplicationDbContext db,
+        CancellationToken ct)
     {
         var appUser = await db.AppUsers
-            .FirstOrDefaultAsync(u => u.Id == id);
+            .FirstOrDefaultAsync(u => u.Id == id, ct);
 
         if (appUser is null)
         {

--- a/src/backend/Teeforce.Api/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/Data/ApplicationDbContext.cs
@@ -79,6 +79,9 @@ public class ApplicationDbContext(
         modelBuilder.Entity<Course>()
             .HasQueryFilter(c => CurrentOrganizationId == null || c.OrganizationId == CurrentOrganizationId);
 
+        modelBuilder.Entity<AppUser>()
+            .HasQueryFilter(u => !u.IsDeleted);
+
         // Apply domain entity configurations
         modelBuilder.ApplyConfiguration(new OrganizationConfiguration());
         modelBuilder.ApplyConfiguration(new AppUserConfiguration());

--- a/src/backend/Teeforce.Api/Infrastructure/EntityTypeConfigurations/AppUserConfiguration.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/EntityTypeConfigurations/AppUserConfiguration.cs
@@ -22,6 +22,8 @@ public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
         builder.Property(u => u.IsActive);
         builder.Property(u => u.CreatedAt);
         builder.Property(u => u.InviteSentAt).IsRequired(false);
+        builder.Property(u => u.IsDeleted).HasDefaultValue(false);
+        builder.Property(u => u.DeletedAt).IsRequired(false);
 
         builder.HasOne<Organization>()
             .WithMany()

--- a/src/backend/Teeforce.Api/Infrastructure/Services/GraphAppUserDeletionService.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/Services/GraphAppUserDeletionService.cs
@@ -1,0 +1,15 @@
+using Microsoft.Graph;
+using Teeforce.Domain.Services;
+
+namespace Teeforce.Api.Infrastructure.Services;
+
+public class GraphAppUserDeletionService(
+    GraphServiceClient graphClient,
+    ILogger<GraphAppUserDeletionService> logger) : IAppUserDeletionService
+{
+    public async Task DeleteAsync(string identityId, CancellationToken ct = default)
+    {
+        await graphClient.Users[identityId].DeleteAsync(cancellationToken: ct);
+        logger.LogInformation("Deleted Entra user {IdentityId}", identityId);
+    }
+}

--- a/src/backend/Teeforce.Api/Infrastructure/Services/NoOpAppUserDeletionService.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/Services/NoOpAppUserDeletionService.cs
@@ -1,0 +1,12 @@
+using Teeforce.Domain.Services;
+
+namespace Teeforce.Api.Infrastructure.Services;
+
+public class NoOpAppUserDeletionService(ILogger<NoOpAppUserDeletionService> logger) : IAppUserDeletionService
+{
+    public Task DeleteAsync(string identityId, CancellationToken ct = default)
+    {
+        logger.LogInformation("NoOp deletion for IdentityId {IdentityId}. Configure Graph settings for real deletions.", identityId);
+        return Task.CompletedTask;
+    }
+}

--- a/src/backend/Teeforce.Api/Migrations/20260406180628_AddAppUserSoftDelete.Designer.cs
+++ b/src/backend/Teeforce.Api/Migrations/20260406180628_AddAppUserSoftDelete.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Teeforce.Api.Infrastructure.Data;
 
@@ -12,9 +13,11 @@ using Teeforce.Api.Infrastructure.Data;
 namespace Teeforce.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406180628_AddAppUserSoftDelete")]
+    partial class AddAppUserSoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/Teeforce.Api/Migrations/20260406180628_AddAppUserSoftDelete.cs
+++ b/src/backend/Teeforce.Api/Migrations/20260406180628_AddAppUserSoftDelete.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Teeforce.Api.Migrations;
+
+/// <inheritdoc />
+public partial class AddAppUserSoftDelete : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "DeletedAt",
+            table: "AppUsers",
+            type: "datetimeoffset",
+            nullable: true);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "IsDeleted",
+            table: "AppUsers",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "DeletedAt",
+            table: "AppUsers");
+
+        migrationBuilder.DropColumn(
+            name: "IsDeleted",
+            table: "AppUsers");
+    }
+}

--- a/src/backend/Teeforce.Api/Program.cs
+++ b/src/backend/Teeforce.Api/Program.cs
@@ -110,6 +110,7 @@ var useDevAuth = builder.Configuration.GetSection(AuthSettings.SectionName).Get<
 if (useDevAuth)
 {
     builder.Services.AddScoped<IAppUserInvitationService, NoOpAppUserInvitationService>();
+    builder.Services.AddScoped<IAppUserDeletionService, NoOpAppUserDeletionService>();
     builder.Services.AddScoped<IAppUserClaimsProvider, DevAppUserClaimsProvider>();
 }
 else
@@ -123,6 +124,7 @@ else
         });
     builder.Services.AddSingleton(_ => new GraphServiceClient(credential));
     builder.Services.AddScoped<IAppUserInvitationService, GraphAppUserInvitationService>();
+    builder.Services.AddScoped<IAppUserDeletionService, GraphAppUserDeletionService>();
     builder.Services.AddScoped<IAppUserClaimsProvider, AppUserClaimsProvider>();
 }
 builder.Services.AddScoped<IAppUserEmailUniquenessChecker, AppUserEmailUniquenessChecker>();

--- a/src/backend/Teeforce.Domain/AppUserAggregate/AppUser.cs
+++ b/src/backend/Teeforce.Domain/AppUserAggregate/AppUser.cs
@@ -152,6 +152,11 @@ public class AppUser : Entity
 
     public void Delete()
     {
+        if (IsDeleted)
+        {
+            return;
+        }
+
         IsDeleted = true;
         DeletedAt = DateTimeOffset.UtcNow;
 

--- a/src/backend/Teeforce.Domain/AppUserAggregate/AppUser.cs
+++ b/src/backend/Teeforce.Domain/AppUserAggregate/AppUser.cs
@@ -16,6 +16,8 @@ public class AppUser : Entity
     public bool IsActive { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? InviteSentAt { get; private set; }
+    public bool IsDeleted { get; private set; }
+    public DateTimeOffset? DeletedAt { get; private set; }
 
     private AppUser() { } // EF
 
@@ -147,4 +149,16 @@ public class AppUser : Entity
     public void Deactivate() => IsActive = false;
 
     public void Activate() => IsActive = true;
+
+    public void Delete()
+    {
+        IsDeleted = true;
+        DeletedAt = DateTimeOffset.UtcNow;
+
+        AddDomainEvent(new AppUserDeleted
+        {
+            AppUserId = Id,
+            IdentityId = IdentityId,
+        });
+    }
 }

--- a/src/backend/Teeforce.Domain/AppUserAggregate/Events/AppUserDeleted.cs
+++ b/src/backend/Teeforce.Domain/AppUserAggregate/Events/AppUserDeleted.cs
@@ -1,0 +1,11 @@
+using Teeforce.Domain.Common;
+
+namespace Teeforce.Domain.AppUserAggregate.Events;
+
+public record AppUserDeleted : IDomainEvent
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+    public required Guid AppUserId { get; init; }
+    public required string? IdentityId { get; init; }
+}

--- a/src/backend/Teeforce.Domain/Services/IAppUserDeletionService.cs
+++ b/src/backend/Teeforce.Domain/Services/IAppUserDeletionService.cs
@@ -1,0 +1,6 @@
+namespace Teeforce.Domain.Services;
+
+public interface IAppUserDeletionService
+{
+    Task DeleteAsync(string identityId, CancellationToken ct = default);
+}

--- a/src/web/src/features/admin/hooks/useUsers.ts
+++ b/src/web/src/features/admin/hooks/useUsers.ts
@@ -59,3 +59,13 @@ export function useUpdateUser() {
     },
   });
 }
+
+export function useDeleteUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/auth/users/${id}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
+    },
+  });
+}

--- a/src/web/src/features/admin/pages/CourseCreate.tsx
+++ b/src/web/src/features/admin/pages/CourseCreate.tsx
@@ -2,7 +2,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
-import { useNavigate, Link } from 'react-router';
+import { useNavigate, Link, useSearchParams } from 'react-router';
 import { getBrowserTimeZone } from '@/lib/course-time';
 import { api } from '@/lib/api-client';
 import type { Course } from '@/types/course';
@@ -42,12 +42,14 @@ type CourseFormData = z.infer<typeof courseSchema>;
 export default function CourseCreate() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const preselectedOrgId = searchParams.get('organizationId') ?? '';
   const { data: organizations, isLoading: isLoadingOrgs, error: orgsError } = useOrganizations();
 
   const form = useForm<CourseFormData>({
     resolver: zodResolver(courseSchema),
     defaultValues: {
-      organizationId: '',
+      organizationId: preselectedOrgId,
       name: '',
       timeZoneId: getBrowserTimeZone(),
       streetAddress: '',

--- a/src/web/src/features/admin/pages/OrgDetail.tsx
+++ b/src/web/src/features/admin/pages/OrgDetail.tsx
@@ -128,8 +128,13 @@ export default function OrgDetail() {
       </Card>
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Courses</CardTitle>
+          {id && (
+            <Button variant="outline" size="sm" asChild>
+              <Link to={`/admin/courses/new?organizationId=${id}`}>Register Course</Link>
+            </Button>
+          )}
         </CardHeader>
         <CardContent className="p-0">
           {isLoading ? (
@@ -166,8 +171,13 @@ export default function OrgDetail() {
       </Card>
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Users</CardTitle>
+          {id && (
+            <Button variant="outline" size="sm" asChild>
+              <Link to={`/admin/users/new?organizationId=${id}`}>Create User</Link>
+            </Button>
+          )}
         </CardHeader>
         <CardContent className="p-0">
           {isLoading ? (

--- a/src/web/src/features/admin/pages/UserCreate.tsx
+++ b/src/web/src/features/admin/pages/UserCreate.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, Link } from 'react-router';
+import { useNavigate, Link, useSearchParams } from 'react-router';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod/v4';
@@ -51,6 +51,8 @@ type UserFormData = z.infer<typeof userSchema>;
 
 export default function UserCreate() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const preselectedOrgId = searchParams.get('organizationId') ?? '';
   const { data: orgs, isLoading: isLoadingOrgs } = useOrganizations();
   const createUser = useCreateUser();
 
@@ -59,7 +61,7 @@ export default function UserCreate() {
     defaultValues: {
       email: '',
       role: 'Operator',
-      organizationId: '',
+      organizationId: preselectedOrgId,
       sendInvite: false,
     },
   });

--- a/src/web/src/features/admin/pages/UserDetail.tsx
+++ b/src/web/src/features/admin/pages/UserDetail.tsx
@@ -1,6 +1,6 @@
-import { useParams, Link } from 'react-router';
+import { useParams, Link, useNavigate } from 'react-router';
 import { useState } from 'react';
-import { useUsers, useUpdateUser, useInviteUser } from '../hooks/useUsers';
+import { useUsers, useUpdateUser, useInviteUser, useDeleteUser } from '../hooks/useUsers';
 import { useOrganizations } from '../hooks/useOrganizations';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -17,6 +17,17 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 export default function UserDetail() {
   const { id } = useParams<{ id: string }>();
@@ -24,6 +35,8 @@ export default function UserDetail() {
   const { data: orgs, isLoading: isLoadingOrgs } = useOrganizations();
   const updateUser = useUpdateUser();
   const inviteUser = useInviteUser();
+  const navigate = useNavigate();
+  const deleteUser = useDeleteUser();
 
   const user = users?.find((u) => u.id === id);
 
@@ -76,6 +89,15 @@ export default function UserDetail() {
     updateUser.mutate({
       id: user.id,
       isActive: !user.isActive,
+    });
+  }
+
+  function handleDelete() {
+    if (!user) return;
+    deleteUser.mutate(user.id, {
+      onSuccess: () => {
+        void navigate('/admin/users');
+      },
     });
   }
 
@@ -206,6 +228,25 @@ export default function UserDetail() {
                   ? 'Resend Invite'
                   : 'Send Invite'}
             </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" disabled={deleteUser.isPending}>
+                  {deleteUser.isPending ? 'Deleting...' : 'Delete User'}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete user?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently remove the user from Entra ID. This cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete}>Delete</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </CardContent>
       </Card>

--- a/tests/Teeforce.Api.Tests/Features/AppUsers/Handlers/AppUserDeleted/DeleteEntraUserHandlerTests.cs
+++ b/tests/Teeforce.Api.Tests/Features/AppUsers/Handlers/AppUserDeleted/DeleteEntraUserHandlerTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Teeforce.Api.Features.AppUsers.Handlers.AppUserDeleted;
+using Teeforce.Domain.Services;
+using AppUserDeletedEvent = Teeforce.Domain.AppUserAggregate.Events.AppUserDeleted;
+
+namespace Teeforce.Api.Tests.Features.AppUsers.Handlers.AppUserDeleted;
+
+public class DeleteEntraUserHandlerTests
+{
+    private readonly IAppUserDeletionService deletionService = Substitute.For<IAppUserDeletionService>();
+    private readonly ILogger logger = Substitute.For<ILogger>();
+
+    [Fact]
+    public async Task Handle_WithIdentityId_CallsDeletionService()
+    {
+        var evt = new AppUserDeletedEvent
+        {
+            AppUserId = Guid.CreateVersion7(),
+            IdentityId = "entra-oid-123",
+        };
+
+        await DeleteEntraUserHandler.Handle(evt, this.deletionService, this.logger, CancellationToken.None);
+
+        await this.deletionService.Received(1).DeleteAsync("entra-oid-123", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNullIdentityId_SkipsDeletionService()
+    {
+        var evt = new AppUserDeletedEvent
+        {
+            AppUserId = Guid.CreateVersion7(),
+            IdentityId = null,
+        };
+
+        await DeleteEntraUserHandler.Handle(evt, this.deletionService, this.logger, CancellationToken.None);
+
+        await this.deletionService.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Teeforce.Domain.Tests/AppUserAggregate/AppUserTests.cs
+++ b/tests/Teeforce.Domain.Tests/AppUserAggregate/AppUserTests.cs
@@ -203,4 +203,34 @@ public class AppUserTests
         var createdEvent = user.DomainEvents.OfType<AppUserCreated>().Single();
         Assert.True(createdEvent.ShouldSendInvite);
     }
+
+    [Fact]
+    public async Task Delete_SetsIsDeletedAndDeletedAtAndRaisesEvent()
+    {
+        var user = await AppUser.CreateAdmin("admin@example.com", NewChecker());
+        user.CompleteIdentitySetup("entra-oid-123", "Jane", "Smith");
+        user.ClearDomainEvents();
+
+        user.Delete();
+
+        Assert.True(user.IsDeleted);
+        Assert.NotNull(user.DeletedAt);
+        Assert.True(user.DeletedAt >= DateTimeOffset.UtcNow.AddSeconds(-2));
+        var deletedEvent = user.DomainEvents.OfType<AppUserDeleted>().Single();
+        Assert.Equal(user.Id, deletedEvent.AppUserId);
+        Assert.Equal("entra-oid-123", deletedEvent.IdentityId);
+    }
+
+    [Fact]
+    public async Task Delete_WithoutIdentityId_EventHasNullIdentityId()
+    {
+        var user = await AppUser.CreateAdmin("admin@example.com", NewChecker());
+        user.ClearDomainEvents();
+
+        user.Delete();
+
+        Assert.True(user.IsDeleted);
+        var deletedEvent = user.DomainEvents.OfType<AppUserDeleted>().Single();
+        Assert.Null(deletedEvent.IdentityId);
+    }
 }

--- a/tests/Teeforce.Domain.Tests/AppUserAggregate/AppUserTests.cs
+++ b/tests/Teeforce.Domain.Tests/AppUserAggregate/AppUserTests.cs
@@ -233,4 +233,17 @@ public class AppUserTests
         var deletedEvent = user.DomainEvents.OfType<AppUserDeleted>().Single();
         Assert.Null(deletedEvent.IdentityId);
     }
+
+    [Fact]
+    public async Task Delete_AlreadyDeleted_IsIdempotent()
+    {
+        var user = await AppUser.CreateAdmin("admin@example.com", NewChecker());
+        user.Delete();
+        user.ClearDomainEvents();
+
+        user.Delete();
+
+        Assert.Empty(user.DomainEvents);
+        Assert.True(user.IsDeleted);
+    }
 }


### PR DESCRIPTION
## Summary

- **Soft-delete users**: `AppUser.Delete()` sets `IsDeleted`/`DeletedAt`, raises `AppUserDeleted` event. Global EF query filter excludes deleted users. `DELETE /auth/users/{id}` endpoint added.
- **Entra cleanup**: `DeleteEntraUserHandler` handles `AppUserDeleted` and calls Microsoft Graph API to delete the Entra ID user (via `IAppUserDeletionService` with Graph/NoOp implementations).
- **OrgDetail shortcut buttons**: "Create User" and "Register Course" buttons on the organization detail page, linking to existing create pages with the org pre-selected via query param.
- **Delete button on UserDetail**: Destructive button with AlertDialog confirmation dialog.

## Test plan

- [ ] `dotnet test` — 363 tests passing (135 domain + 229 API), including 3 new Delete tests and 2 new handler tests
- [ ] `pnpm lint` — clean
- [ ] Navigate to org detail → verify "Create User" and "Register Course" buttons appear
- [ ] Click "Create User" from org detail → verify org is pre-selected on UserCreate
- [ ] Click "Register Course" from org detail → verify org is pre-selected on CourseCreate
- [ ] Navigate to user detail → verify "Delete User" button appears
- [ ] Click "Delete User" → verify confirmation dialog appears
- [ ] Confirm deletion → verify user disappears from list and API returns 404 for that user

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)