### PR TITLE
fix: return 400 instead of 500 when walkup verify Code is null

### DIFF
--- a/src/backend/Teeforce.Api/Features/Waitlist/Endpoints/WalkUpJoinEndpoints.cs
+++ b/src/backend/Teeforce.Api/Features/Waitlist/Endpoints/WalkUpJoinEndpoints.cs
@@ -136,6 +136,7 @@ public class VerifyCodeRequestValidator : AbstractValidator<VerifyCodeRequest>
     public VerifyCodeRequestValidator()
     {
         RuleFor(x => x.Code)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty().WithMessage("Code is required.")
             .Length(4).WithMessage("Code must be exactly 4 digits.")
             .Must(c => c.All(char.IsDigit)).WithMessage("Code must be exactly 4 digits.");

--- a/tests/Teeforce.Api.Tests/Features/Waitlist/Validators/VerifyCodeRequestValidatorTests.cs
+++ b/tests/Teeforce.Api.Tests/Features/Waitlist/Validators/VerifyCodeRequestValidatorTests.cs
@@ -26,4 +26,11 @@ public class VerifyCodeRequestValidatorTests
     [InlineData("12ab")]
     public void InvalidFormat_Fails(string code) =>
         Assert.False(this.validator.Validate(new VerifyCodeRequest(code)).IsValid);
+
+    [Fact]
+    public void NullCode_Fails()
+    {
+        var result = this.validator.Validate(new VerifyCodeRequest(null!));
+        Assert.False(result.IsValid);
+    }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `VerifyCodeRequestValidator`'s `.Must(c => c.All(char.IsDigit))` throws `ArgumentNullException` when `Code` is null because FluentValidation's default `CascadeMode.Continue` runs all rules even after `NotEmpty()` fails
- Added `Cascade(CascadeMode.Stop)` so validation halts at the first failure, returning a proper 400 instead of 500
- Added unit test for null `Code` input

Closes #358

## Test plan

- [x] New `NullCode_Fails` test passes
- [x] All 230 existing unit tests pass
- [ ] Verify in deployed test env: `POST /walkup/verify` with `{"shortCode":"8695"}` returns 400, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)