### PR TITLE
refactor: consolidate Graph API services into Infrastructure/GraphApi folder

### DIFF
--- a/src/backend/Teeforce.Api/Infrastructure/GraphApi/GraphAppUserDeletionService.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/GraphApi/GraphAppUserDeletionService.cs
@@ -1,7 +1,7 @@
 using Microsoft.Graph;
 using Teeforce.Domain.Services;
 
-namespace Teeforce.Api.Infrastructure;
+namespace Teeforce.Api.Infrastructure.GraphApi;
 
 public class GraphAppUserDeletionService(
     GraphServiceClient graphClient,

--- a/src/backend/Teeforce.Api/Infrastructure/GraphApi/GraphAppUserInvitationService.cs
+++ b/src/backend/Teeforce.Api/Infrastructure/GraphApi/GraphAppUserInvitationService.cs
@@ -4,7 +4,7 @@ using Microsoft.Graph.Models;
 using Teeforce.Api.Infrastructure.Configuration;
 using Teeforce.Domain.Services;
 
-namespace Teeforce.Api.Infrastructure.AppUsers;
+namespace Teeforce.Api.Infrastructure.GraphApi;
 
 public class GraphAppUserInvitationService(
     GraphServiceClient graphClient,

--- a/src/backend/Teeforce.Api/Program.cs
+++ b/src/backend/Teeforce.Api/Program.cs
@@ -13,6 +13,7 @@ using Teeforce.Api.Infrastructure.Auth;
 using Teeforce.Api.Infrastructure.Configuration;
 using Teeforce.Api.Infrastructure.Data;
 using Teeforce.Api.Infrastructure.Email;
+using Teeforce.Api.Infrastructure.GraphApi;
 using Teeforce.Api.Infrastructure.Middleware;
 using Teeforce.Api.Infrastructure.Notifications;
 using Teeforce.Api.Infrastructure.Observability;


### PR DESCRIPTION
## Summary

- `GraphAppUserInvitationService` was in `Infrastructure/AppUsers/` and `GraphAppUserDeletionService` was directly in `Infrastructure/` — both are Microsoft Graph-backed implementations.
- Moved both into a new `Infrastructure/GraphApi/` folder and updated their namespaces to `Teeforce.Api.Infrastructure.GraphApi`.
- Named the folder `GraphApi` rather than `Graph` to avoid ambiguity with graph (data structure) terminology.
- Added the new `using` to `Program.cs`; the existing `using Teeforce.Api.Infrastructure.AppUsers;` is retained because `NoOpAppUserInvitationService` and `AppUserEmailUniquenessChecker` remain there.

## Test plan

- [x] `dotnet build` — clean, 0 errors
- [x] `dotnet test Teeforce.Domain.Tests` — 135 passed
- [x] `dotnet test Teeforce.Api.Tests` — 260 passed
- [x] `dotnet format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)