### PR TITLE
feat: course schedule defaults (capacity + flexible interval)

### DIFF
--- a/docs/superpowers/specs/2026-04-09-course-schedule-defaults-design.md
+++ b/docs/superpowers/specs/2026-04-09-course-schedule-defaults-design.md
@@ -1,0 +1,67 @@
+# Course Schedule Defaults — Design Spec
+
+**Issue:** #397 — Configure course schedule defaults
+**Date:** 2026-04-09
+
+## Summary
+
+Extend the existing tee-time-settings endpoint and operator settings page to include `DefaultCapacity`, and relax the interval validator from a fixed 8/10/12 enum to any positive integer with a soft warning below 8.
+
+## Scope
+
+Four fields, one endpoint, one form: first tee time, last tee time, interval in minutes, default group capacity.
+
+## What Already Exists
+
+- **Domain**: `Course` aggregate has `TeeTimeIntervalMinutes`, `FirstTeeTime`, `LastTeeTime`, `DefaultCapacity` properties with `UpdateTeeTimeSettings()` and `UpdateDefaultCapacity()` methods. `ScheduleSettings` value object validates all four fields.
+- **Database**: All four columns exist on the Course table. No migration needed.
+- **API**: `GET/PUT /courses/{courseId}/tee-time-settings` endpoints exist but DTOs exclude `DefaultCapacity`. Validator restricts interval to 8, 10, or 12.
+- **Frontend**: `TeeTimeSettings.tsx` page with form for interval (select), first/last tee time. Missing capacity field.
+
+## Changes
+
+### Backend
+
+**DTOs** (`CourseEndpoints.cs`):
+- Add `int DefaultCapacity` to `TeeTimeSettingsRequest` and `TeeTimeSettingsResponse`.
+
+**Validator** (`TeeTimeSettingsRequestValidator`):
+- Change interval rule from "must be 8, 10, or 12" to "must be greater than 0".
+- Add `DefaultCapacity` rule: must be greater than 0.
+
+**PUT handler**:
+- After `course.UpdateTeeTimeSettings(...)`, call `course.UpdateDefaultCapacity(request.DefaultCapacity)`.
+
+**GET handler**:
+- Include `course.DefaultCapacity` in response.
+
+### Frontend
+
+**Type** (`course.ts`):
+- Add `defaultCapacity: number` to `TeeTimeSettings` interface.
+
+**Zod schema** (`TeeTimeSettings.tsx`):
+- Add `defaultCapacity: z.number().int().min(1, "Must be at least 1")`.
+
+**Form** (`TeeTimeSettings.tsx`):
+- Change interval from `<Select>` (8/10/12) to a number input.
+- Show a non-blocking warning (yellow alert) when interval < 8.
+- Add a number input for "Default Group Size" with min 1.
+
+**Hook** (`useTeeTimeSettings.ts`):
+- No structural changes — the existing fetch/mutate handles the full DTO. Just ensure `defaultCapacity` flows through.
+
+### Validation Layers
+
+| Field | Frontend (Zod) | Backend (FluentValidation) | Domain |
+|-------|---------------|---------------------------|--------|
+| Interval | `int, min(1)`, warn < 8 | `> 0` | `> 0` (ScheduleSettings) |
+| First tee | required | `< LastTeeTime` | `< LastTeeTime` |
+| Last tee | required | `> FirstTeeTime` | `> FirstTeeTime` |
+| Capacity | `int, min(1)` | `> 0` | `> 0` |
+
+## Out of Scope
+
+- Per-interval capacity overrides
+- Per-day schedule variations
+- Any new endpoints or pages

--- a/src/backend/Teeforce.Api/Features/Courses/CourseEndpoints.cs
+++ b/src/backend/Teeforce.Api/Features/Courses/CourseEndpoints.cs
@@ -177,11 +177,13 @@ public static class CourseEndpoints
         }
 
         course.UpdateTeeTimeSettings(request.TeeTimeIntervalMinutes, request.FirstTeeTime, request.LastTeeTime);
+        course.UpdateDefaultCapacity(request.DefaultCapacity);
 
         return Results.Ok(new TeeTimeSettingsResponse(
             course.TeeTimeIntervalMinutes!.Value,
             course.FirstTeeTime!.Value,
-            course.LastTeeTime!.Value));
+            course.LastTeeTime!.Value,
+            course.DefaultCapacity));
     }
 
     [WolverineGet("/courses/{courseId}/tee-time-settings")]
@@ -203,7 +205,8 @@ public static class CourseEndpoints
         return Results.Ok(new TeeTimeSettingsResponse(
             course.TeeTimeIntervalMinutes.Value,
             course.FirstTeeTime.Value,
-            course.LastTeeTime.Value));
+            course.LastTeeTime.Value,
+            course.DefaultCapacity));
     }
 
     [WolverinePut("/courses/{courseId}/pricing")]
@@ -276,12 +279,14 @@ public sealed record UpdateCourseRequest(string Name, string TimeZoneId);
 public record TeeTimeSettingsRequest(
     int TeeTimeIntervalMinutes,
     TimeOnly FirstTeeTime,
-    TimeOnly LastTeeTime);
+    TimeOnly LastTeeTime,
+    int DefaultCapacity);
 
 public record TeeTimeSettingsResponse(
     int TeeTimeIntervalMinutes,
     TimeOnly FirstTeeTime,
-    TimeOnly LastTeeTime);
+    TimeOnly LastTeeTime,
+    int DefaultCapacity);
 
 public record PricingRequest(decimal FlatRatePrice);
 
@@ -335,15 +340,16 @@ public class PricingRequestValidator : AbstractValidator<PricingRequest>
 
 public class TeeTimeSettingsRequestValidator : AbstractValidator<TeeTimeSettingsRequest>
 {
-    private static readonly int[] allowedIntervals = [8, 10, 12];
-
     public TeeTimeSettingsRequestValidator()
     {
         RuleFor(x => x.TeeTimeIntervalMinutes)
-            .Must(i => allowedIntervals.Contains(i))
-            .WithMessage("Interval must be 8, 10, or 12 minutes.");
+            .GreaterThan(0)
+            .WithMessage("Interval must be greater than 0.");
         RuleFor(x => x.FirstTeeTime)
             .LessThan(x => x.LastTeeTime)
             .WithMessage("First tee time must be before last tee time.");
+        RuleFor(x => x.DefaultCapacity)
+            .GreaterThan(0)
+            .WithMessage("Default capacity must be greater than 0.");
     }
 }

--- a/src/web/src/components/ui/alert.tsx
+++ b/src/web/src/components/ui/alert.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+        warning: "border-amber-200 bg-amber-50 text-amber-900 [&>svg]:text-amber-600",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/web/src/components/ui/alert.tsx
+++ b/src/web/src/components/ui/alert.tsx
@@ -11,7 +11,6 @@ const alertVariants = cva(
         default: "bg-card text-card-foreground",
         destructive:
           "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
-        warning: "border-amber-200 bg-amber-50 text-amber-900 [&>svg]:text-amber-600",
       },
     },
     defaultVariants: {

--- a/src/web/src/components/ui/warning-alert.tsx
+++ b/src/web/src/components/ui/warning-alert.tsx
@@ -1,0 +1,9 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+export function WarningAlert({ children }: { children: React.ReactNode }) {
+  return (
+    <Alert className="border-amber-200 bg-amber-50 text-amber-900 [&>svg]:text-amber-600">
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/web/src/components/ui/warning-alert.tsx
+++ b/src/web/src/components/ui/warning-alert.tsx
@@ -1,6 +1,7 @@
+import type { ReactNode } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
-export function WarningAlert({ children }: { children: React.ReactNode }) {
+export function WarningAlert({ children }: { children: ReactNode }) {
   return (
     <Alert className="border-amber-200 bg-amber-50 text-amber-900 [&>svg]:text-amber-600">
       <AlertDescription>{children}</AlertDescription>

--- a/src/web/src/features/operator/pages/TeeTimeSettings.tsx
+++ b/src/web/src/features/operator/pages/TeeTimeSettings.tsx
@@ -2,17 +2,11 @@ import { useEffect } from 'react';
 import { PageTopbar } from '@/components/layout/PageTopbar';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Form,
   FormControl,
@@ -28,11 +22,10 @@ import {
 import { useCourseContext } from '../context/CourseContext';
 
 const teeTimeSettingsSchema = z.object({
-  teeTimeIntervalMinutes: z.number().refine((val) => [8, 10, 12].includes(val), {
-    message: 'Interval must be 8, 10, or 12 minutes',
-  }),
+  teeTimeIntervalMinutes: z.number().int().min(1, 'Interval must be at least 1 minute'),
   firstTeeTime: z.string().min(1, 'First tee time is required'),
   lastTeeTime: z.string().min(1, 'Last tee time is required'),
+  defaultCapacity: z.number().int().min(1, 'Must be at least 1'),
 });
 
 type TeeTimeSettingsFormData = z.infer<typeof teeTimeSettingsSchema>;
@@ -46,6 +39,7 @@ export default function TeeTimeSettings() {
       teeTimeIntervalMinutes: 10,
       firstTeeTime: '07:00',
       lastTeeTime: '18:00',
+      defaultCapacity: 4,
     },
   });
 
@@ -53,6 +47,7 @@ export default function TeeTimeSettings() {
   const updateMutation = useUpdateTeeTimeSettings();
 
   const formIsDirty = form.formState.isDirty;
+  const intervalValue = form.watch('teeTimeIntervalMinutes');
 
   useEffect(() => {
     if (formIsDirty) {
@@ -71,6 +66,7 @@ export default function TeeTimeSettings() {
         teeTimeIntervalMinutes: settingsQuery.data.teeTimeIntervalMinutes,
         firstTeeTime: settingsQuery.data.firstTeeTime.slice(0, 5),
         lastTeeTime: settingsQuery.data.lastTeeTime.slice(0, 5),
+        defaultCapacity: settingsQuery.data.defaultCapacity,
       });
     }
   }, [settingsQuery.data, form]);
@@ -113,26 +109,27 @@ export default function TeeTimeSettings() {
                   name="teeTimeIntervalMinutes"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Tee Time Interval</FormLabel>
-                      <Select
-                        value={String(field.value)}
-                        onValueChange={(value) => field.onChange(Number(value))}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select interval" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="8">Every 8 minutes</SelectItem>
-                          <SelectItem value="10">Every 10 minutes</SelectItem>
-                          <SelectItem value="12">Every 12 minutes</SelectItem>
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Tee Time Interval (minutes)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          {...field}
+                          onChange={(e) => field.onChange(Number(e.target.value))}
+                        />
+                      </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
+
+                {intervalValue > 0 && intervalValue < 8 && (
+                  <Alert variant="warning">
+                    <AlertDescription>
+                      Most courses use intervals of 8 minutes or more. Short intervals may cause pace-of-play issues.
+                    </AlertDescription>
+                  </Alert>
+                )}
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <FormField
@@ -163,6 +160,25 @@ export default function TeeTimeSettings() {
                     )}
                   />
                 </div>
+
+                <FormField
+                  control={form.control}
+                  name="defaultCapacity"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default Group Size</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          {...field}
+                          onChange={(e) => field.onChange(Number(e.target.value))}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
                 {updateMutation.isError && (
                   <p className="text-destructive text-sm">

--- a/src/web/src/features/operator/pages/TeeTimeSettings.tsx
+++ b/src/web/src/features/operator/pages/TeeTimeSettings.tsx
@@ -6,7 +6,7 @@ import { z } from 'zod/v4';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import { WarningAlert } from '@/components/ui/warning-alert';
 import {
   Form,
   FormControl,
@@ -25,7 +25,7 @@ const teeTimeSettingsSchema = z.object({
   teeTimeIntervalMinutes: z.number().int().min(1, 'Interval must be at least 1 minute'),
   firstTeeTime: z.string().min(1, 'First tee time is required'),
   lastTeeTime: z.string().min(1, 'Last tee time is required'),
-  defaultCapacity: z.number().int().min(1, 'Must be at least 1'),
+  defaultCapacity: z.number().int().min(1, 'Default group size must be at least 1'),
 });
 
 type TeeTimeSettingsFormData = z.infer<typeof teeTimeSettingsSchema>;
@@ -115,7 +115,7 @@ export default function TeeTimeSettings() {
                           type="number"
                           min={1}
                           {...field}
-                          onChange={(e) => field.onChange(Number(e.target.value))}
+                          onChange={(e) => field.onChange(e.target.valueAsNumber)}
                         />
                       </FormControl>
                       <FormMessage />
@@ -124,11 +124,9 @@ export default function TeeTimeSettings() {
                 />
 
                 {intervalValue > 0 && intervalValue < 8 && (
-                  <Alert variant="warning">
-                    <AlertDescription>
-                      Most courses use intervals of 8 minutes or more. Short intervals may cause pace-of-play issues.
-                    </AlertDescription>
-                  </Alert>
+                  <WarningAlert>
+                    Most courses use intervals of 8 minutes or more. Short intervals may cause pace-of-play issues.
+                  </WarningAlert>
                 )}
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -172,7 +170,7 @@ export default function TeeTimeSettings() {
                           type="number"
                           min={1}
                           {...field}
-                          onChange={(e) => field.onChange(Number(e.target.value))}
+                          onChange={(e) => field.onChange(e.target.valueAsNumber)}
                         />
                       </FormControl>
                       <FormMessage />

--- a/src/web/src/types/course.ts
+++ b/src/web/src/types/course.ts
@@ -18,6 +18,7 @@ export interface TeeTimeSettings {
   teeTimeIntervalMinutes: number;
   firstTeeTime: string;
   lastTeeTime: string;
+  defaultCapacity: number;
 }
 
 export interface Pricing {

--- a/tests/Teeforce.Api.IntegrationTests/CourseAccessIsolationTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/CourseAccessIsolationTests.cs
@@ -79,7 +79,8 @@ public class CourseAccessIsolationTests(TestWebApplicationFactory factory) : IAs
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "18:00"
+            LastTeeTime = "18:00",
+            DefaultCapacity = 4
         });
 
         // Assert: Operator A cannot see Course B (different org) — EF query filter + CourseExistsMiddleware returns 404

--- a/tests/Teeforce.Api.IntegrationTests/Policies/TeeTimeOpeningOfferPolicyIntegrationTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/Policies/TeeTimeOpeningOfferPolicyIntegrationTests.cs
@@ -92,7 +92,8 @@ public class TeeTimeOpeningOfferPolicyIntegrationTests(TestWebApplicationFactory
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "17:00"
+            LastTeeTime = "17:00",
+            DefaultCapacity = 4
         });
 
         return (tenantId, course.Id);

--- a/tests/Teeforce.Api.IntegrationTests/ResponseDtos.cs
+++ b/tests/Teeforce.Api.IntegrationTests/ResponseDtos.cs
@@ -85,7 +85,8 @@ public record ErrorResponse(string Error);
 public record TeeTimeSettingsResponse(
     int TeeTimeIntervalMinutes,
     string FirstTeeTime,
-    string LastTeeTime);
+    string LastTeeTime,
+    int DefaultCapacity);
 
 public record PricingResponse(decimal FlatRatePrice);
 

--- a/tests/Teeforce.Api.IntegrationTests/TeeSheetDirectBookingTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/TeeSheetDirectBookingTests.cs
@@ -52,7 +52,8 @@ public class TeeSheetDirectBookingTests(TestWebApplicationFactory factory) : IAs
             {
                 TeeTimeIntervalMinutes = 10,
                 FirstTeeTime = firstTime,
-                LastTeeTime = lastTime
+                LastTeeTime = lastTime,
+                DefaultCapacity = 4
             });
         settingsResponse.EnsureSuccessStatusCode();
 

--- a/tests/Teeforce.Api.IntegrationTests/TeeSheetEndpointsTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/TeeSheetEndpointsTests.cs
@@ -116,7 +116,8 @@ public class TeeSheetEndpointsTests(TestWebApplicationFactory factory) : IAsyncL
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "17:00"
+            LastTeeTime = "17:00",
+            DefaultCapacity = 4
         });
 
         await DraftAndPublishSheetAsync(course.Id, "2026-02-07");
@@ -145,7 +146,8 @@ public class TeeSheetEndpointsTests(TestWebApplicationFactory factory) : IAsyncL
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "08:00"
+            LastTeeTime = "08:00",
+            DefaultCapacity = 4
         });
 
         await DraftAndPublishSheetAsync(course.Id, "2026-02-07");
@@ -187,7 +189,8 @@ public class TeeSheetEndpointsTests(TestWebApplicationFactory factory) : IAsyncL
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "08:00"
+            LastTeeTime = "08:00",
+            DefaultCapacity = 4
         });
 
         await DraftAndPublishSheetAsync(course.Id, "2026-02-07");
@@ -249,7 +252,8 @@ public class TeeSheetEndpointsTests(TestWebApplicationFactory factory) : IAsyncL
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "08:00"
+            LastTeeTime = "08:00",
+            DefaultCapacity = 4
         });
 
         await DraftAndPublishSheetAsync(course.Id, "2026-02-07");
@@ -275,7 +279,8 @@ public class TeeSheetEndpointsTests(TestWebApplicationFactory factory) : IAsyncL
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "07:30"
+            LastTeeTime = "07:30",
+            DefaultCapacity = 4
         });
 
         await DraftAndPublishSheetAsync(course.Id, "2026-02-07");

--- a/tests/Teeforce.Api.IntegrationTests/TeeTimeSettingsTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/TeeTimeSettingsTests.cs
@@ -49,7 +49,8 @@ public class TeeTimeSettingsTests(TestWebApplicationFactory factory) : IAsyncLif
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "18:00"
+            LastTeeTime = "18:00",
+            DefaultCapacity = 4
         });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -59,6 +60,7 @@ public class TeeTimeSettingsTests(TestWebApplicationFactory factory) : IAsyncLif
         Assert.Equal(10, body!.TeeTimeIntervalMinutes);
         Assert.Equal("07:00:00", body.FirstTeeTime);
         Assert.Equal("18:00:00", body.LastTeeTime);
+        Assert.Equal(4, body.DefaultCapacity);
     }
 
     [Fact]
@@ -68,7 +70,8 @@ public class TeeTimeSettingsTests(TestWebApplicationFactory factory) : IAsyncLif
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "18:00"
+            LastTeeTime = "18:00",
+            DefaultCapacity = 4
         });
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -83,7 +86,8 @@ public class TeeTimeSettingsTests(TestWebApplicationFactory factory) : IAsyncLif
         {
             TeeTimeIntervalMinutes = 8,
             FirstTeeTime = "06:30",
-            LastTeeTime = "17:30"
+            LastTeeTime = "17:30",
+            DefaultCapacity = 4
         });
 
         var response = await this.client.GetAsync($"/courses/{courseId}/tee-time-settings");
@@ -94,6 +98,7 @@ public class TeeTimeSettingsTests(TestWebApplicationFactory factory) : IAsyncLif
         Assert.Equal(8, body!.TeeTimeIntervalMinutes);
         Assert.Equal("06:30:00", body.FirstTeeTime);
         Assert.Equal("17:30:00", body.LastTeeTime);
+        Assert.Equal(4, body.DefaultCapacity);
     }
 
     [Fact]

--- a/tests/Teeforce.Api.IntegrationTests/TenantCourseIsolationTests.cs
+++ b/tests/Teeforce.Api.IntegrationTests/TenantCourseIsolationTests.cs
@@ -124,7 +124,8 @@ public class TenantCourseIsolationTests(TestWebApplicationFactory factory) : IAs
         {
             TeeTimeIntervalMinutes = 10,
             FirstTeeTime = "07:00",
-            LastTeeTime = "18:00"
+            LastTeeTime = "18:00",
+            DefaultCapacity = 4
         });
 
         // Assert

--- a/tests/Teeforce.Api.Tests/Features/TeeSheet/Validators/TeeTimeSettingsRequestValidatorTests.cs
+++ b/tests/Teeforce.Api.Tests/Features/TeeSheet/Validators/TeeTimeSettingsRequestValidatorTests.cs
@@ -10,25 +10,49 @@ public class TeeTimeSettingsRequestValidatorTests
 
     [Fact]
     public void Valid_Request_Passes() =>
-        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00")))
+        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00"), 4))
             .ShouldNotHaveAnyValidationErrors();
 
     [Theory]
+    [InlineData(1)]
     [InlineData(5)]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(12)]
     [InlineData(15)]
+    public void Positive_Interval_Passes(int interval) =>
+        this.validator.TestValidate(new TeeTimeSettingsRequest(interval, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00"), 4))
+            .ShouldNotHaveValidationErrorFor(x => x.TeeTimeIntervalMinutes);
+
+    [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public void Invalid_Interval_Fails(int interval) =>
-        this.validator.TestValidate(new TeeTimeSettingsRequest(interval, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00")))
+    public void Non_Positive_Interval_Fails(int interval) =>
+        this.validator.TestValidate(new TeeTimeSettingsRequest(interval, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00"), 4))
             .ShouldHaveValidationErrorFor(x => x.TeeTimeIntervalMinutes);
 
     [Fact]
     public void FirstTeeTime_After_LastTeeTime_Fails() =>
-        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("18:00"), TimeOnly.Parse("07:00")))
+        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("18:00"), TimeOnly.Parse("07:00"), 4))
             .ShouldHaveValidationErrorFor(x => x.FirstTeeTime);
 
     [Fact]
     public void FirstTeeTime_Equals_LastTeeTime_Fails() =>
-        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("07:00")))
+        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("07:00"), 4))
             .ShouldHaveValidationErrorFor(x => x.FirstTeeTime);
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(8)]
+    public void Positive_DefaultCapacity_Passes(int capacity) =>
+        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00"), capacity))
+            .ShouldNotHaveValidationErrorFor(x => x.DefaultCapacity);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Non_Positive_DefaultCapacity_Fails(int capacity) =>
+        this.validator.TestValidate(new TeeTimeSettingsRequest(10, TimeOnly.Parse("07:00"), TimeOnly.Parse("18:00"), capacity))
+            .ShouldHaveValidationErrorFor(x => x.DefaultCapacity);
 }

--- a/tests/Teeforce.Domain.Tests/CourseAggregate/CourseScheduleDefaultsTests.cs
+++ b/tests/Teeforce.Domain.Tests/CourseAggregate/CourseScheduleDefaultsTests.cs
@@ -1,5 +1,6 @@
 using Teeforce.Domain.CourseAggregate;
 using Teeforce.Domain.CourseAggregate.Exceptions;
+using Teeforce.Domain.TeeSheetAggregate.Exceptions;
 
 namespace Teeforce.Domain.Tests.CourseAggregate;
 
@@ -25,6 +26,16 @@ public class CourseScheduleDefaultsTests
         var course = Course.Create(Guid.NewGuid(), "Pebble", "America/Los_Angeles");
 
         Assert.Throws<CourseScheduleNotConfiguredException>(() => course.CurrentScheduleDefaults());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void UpdateDefaultCapacity_NonPositive_Throws(int capacity)
+    {
+        var course = Course.Create(Guid.NewGuid(), "Pebble", "America/Los_Angeles");
+
+        Assert.Throws<InvalidScheduleSettingsException>(() => course.UpdateDefaultCapacity(capacity));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `DefaultCapacity` to tee-time-settings GET/PUT endpoint DTOs and handlers
- Relax interval validator from fixed 8/10/12 enum to any positive integer
- Add "Default Group Size" number input and flexible interval input to operator settings form
- Show soft yellow warning when interval < 8 minutes (non-blocking)

Closes #397

## Test plan
- [ ] Validator unit tests cover positive/non-positive for both interval and capacity
- [ ] Domain unit tests cover `UpdateDefaultCapacity` happy + negative paths
- [ ] Integration tests updated — all request bodies include `DefaultCapacity`
- [ ] Save settings with custom interval (e.g. 7) — warning shown, saves OK
- [ ] Save settings with capacity 2 — persists and reloads correctly
- [ ] Existing 8/10/12 intervals still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)