### PR TITLE
chore(web): replace hardcoded colors with semantic dark mode tokens

### DIFF
--- a/src/web/src/components/layout/AppShell.tsx
+++ b/src/web/src/components/layout/AppShell.tsx
@@ -154,7 +154,7 @@ interface TopbarProps {
 
 function Topbar({ brand, onSwitchCourse, setLeft, setMiddle, setRight, showSidebarTrigger }: TopbarProps) {
   return (
-    <header className="grid h-14 shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-5 border-b border-border bg-white px-6">
+    <header className="grid h-14 shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-5 border-b border-border bg-paper px-6">
       <div className="flex items-center gap-5 justify-self-start">
         {showSidebarTrigger && <SidebarTrigger className="md:hidden" />}
         {brand}
@@ -173,7 +173,7 @@ function RightRailRegion({ setRef }: { setRef: (el: HTMLDivElement | null) => vo
   return (
     <aside
       ref={setRef}
-      className="empty:hidden w-[272px] shrink-0 overflow-y-auto border-l border-border bg-white"
+      className="empty:hidden w-[272px] shrink-0 overflow-y-auto border-l border-border bg-paper"
     />
   );
 }

--- a/src/web/src/components/ui/alert-dialog.tsx
+++ b/src/web/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-overlay data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}

--- a/src/web/src/components/ui/dialog.tsx
+++ b/src/web/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay",
         className
       )}
       {...props}

--- a/src/web/src/components/ui/drawer.tsx
+++ b/src/web/src/components/ui/drawer.tsx
@@ -35,7 +35,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-overlay data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}

--- a/src/web/src/components/ui/sheet.tsx
+++ b/src/web/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay",
         className
       )}
       {...props}

--- a/src/web/src/components/ui/sidebar.tsx
+++ b/src/web/src/components/ui/sidebar.tsx
@@ -478,7 +478,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",

--- a/src/web/src/components/ui/warning-alert.tsx
+++ b/src/web/src/components/ui/warning-alert.tsx
@@ -1,14 +1,16 @@
 import type { ReactNode } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
 
 interface WarningAlertProps {
   icon?: ReactNode;
   children: ReactNode;
+  className?: string;
 }
 
-export function WarningAlert({ icon, children }: WarningAlertProps) {
+export function WarningAlert({ icon, children, className }: WarningAlertProps) {
   return (
-    <Alert className="border-orange-light bg-orange-faint text-foreground [&>svg]:text-orange">
+    <Alert className={cn("border-orange-light bg-orange-faint text-foreground [&>svg]:text-orange", className)}>
       {icon}
       <AlertDescription>{children}</AlertDescription>
     </Alert>

--- a/src/web/src/features/admin/pages/CourseList.tsx
+++ b/src/web/src/features/admin/pages/CourseList.tsx
@@ -54,7 +54,7 @@ export default function CourseList() {
       {!courses || courses.length === 0 ? (
         <p className="text-ink-muted text-sm py-12 text-center">No courses registered yet.</p>
       ) : (
-        <div className="border border-border-strong rounded-md bg-white overflow-hidden">
+        <div className="border border-border-strong rounded-md bg-card overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-canvas">

--- a/src/web/src/features/admin/pages/DeadLetters.tsx
+++ b/src/web/src/features/admin/pages/DeadLetters.tsx
@@ -217,7 +217,7 @@ export default function DeadLetters() {
           No dead letter messages. All clear.
         </p>
       ) : (
-        <div className="border border-border-strong rounded-md bg-white overflow-hidden">
+        <div className="border border-border-strong rounded-md bg-card overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-canvas">

--- a/src/web/src/features/admin/pages/OrgList.tsx
+++ b/src/web/src/features/admin/pages/OrgList.tsx
@@ -63,7 +63,7 @@ export default function OrgList() {
       )}
 
       {isLoading ? (
-        <div className="border border-border-strong rounded-md bg-white overflow-hidden">
+        <div className="border border-border-strong rounded-md bg-card overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-canvas">
@@ -83,7 +83,7 @@ export default function OrgList() {
       ) : !orgs || orgs.length === 0 ? (
         <p className="text-ink-muted text-sm py-12 text-center">No organizations yet. Create one to get started.</p>
       ) : (
-        <div className="border border-border-strong rounded-md bg-white overflow-hidden">
+        <div className="border border-border-strong rounded-md bg-card overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-canvas">

--- a/src/web/src/features/admin/pages/UserList.tsx
+++ b/src/web/src/features/admin/pages/UserList.tsx
@@ -65,7 +65,7 @@ export default function UserList() {
       {!users || users.length === 0 ? (
         <p className="text-ink-muted text-sm py-12 text-center">No users yet.</p>
       ) : (
-        <div className="border border-border-strong rounded-md bg-white overflow-hidden">
+        <div className="border border-border-strong rounded-md bg-card overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-canvas">

--- a/src/web/src/features/course/manage/pages/Schedule.tsx
+++ b/src/web/src/features/course/manage/pages/Schedule.tsx
@@ -121,7 +121,7 @@ export default function Schedule() {
       <>
         <PageTopbar middle={<h1 className="text-lg font-semibold">Schedule</h1>} />
         <div className="p-6">
-          <p className="text-muted-foreground">
+          <p className="text-ink-muted">
             Schedule defaults are not configured.{' '}
             <Link to={`/course/${courseId}/manage/settings`} className="underline text-primary">
               Configure settings
@@ -141,7 +141,7 @@ export default function Schedule() {
       />
       <div className="p-6 space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-medium text-muted-foreground">
+          <h2 className="text-sm font-medium text-ink-muted">
             {formatDayLabel(startDateStr)} &ndash;{' '}
             {data?.weekEnd ? formatDayLabel(data.weekEnd) : formatDayLabel(formatDateParam(
               new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + 6),
@@ -206,7 +206,7 @@ function DayCard({ day, courseId, isSelected, onToggle }: DayCardProps) {
         </div>
         <Badge variant={config.variant}>{config.label}</Badge>
         {day.intervalCount != null && (
-          <p className="text-xs text-muted-foreground">{day.intervalCount} intervals</p>
+          <p className="text-xs text-ink-muted">{day.intervalCount} intervals</p>
         )}
       </CardContent>
     </Card>

--- a/src/web/src/features/course/manage/pages/Settings.tsx
+++ b/src/web/src/features/course/manage/pages/Settings.tsx
@@ -87,9 +87,9 @@ export default function Settings() {
       />
 
       {isDirty && (
-        <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+        <WarningAlert className="mb-4">
           You have unsaved changes.
-        </div>
+        </WarningAlert>
       )}
 
       <div className="max-w-2xl">

--- a/src/web/src/features/course/pos/components/OpeningsGrid.tsx
+++ b/src/web/src/features/course/pos/components/OpeningsGrid.tsx
@@ -46,7 +46,7 @@ export function OpeningsGrid({
         <>
           {/* Sticky column header row */}
           <div
-            className="sticky top-0 z-10 grid border-b border-border bg-white px-1 py-1.5 text-[10px] font-medium uppercase tracking-wider text-ink-muted"
+            className="sticky top-0 z-10 grid border-b border-border bg-card px-1 py-1.5 text-[10px] font-medium uppercase tracking-wider text-ink-muted"
             style={{ gridTemplateColumns: GRID_COLS }}
           >
             <span>Time</span>
@@ -71,7 +71,7 @@ export function OpeningsGrid({
                   data-testid={`opening-row-${opening.id}`}
                   className={cn(
                     'grid items-center px-1 py-2.5 text-[13px] transition-colors',
-                    isFaded ? 'bg-canvas text-ink-muted' : 'bg-white text-ink',
+                    isFaded ? 'bg-canvas text-ink-muted' : 'bg-paper text-ink',
                     isCancelling && 'opacity-40',
                     'hover:bg-paper',
                   )}

--- a/src/web/src/features/course/pos/components/QrCodePanel.tsx
+++ b/src/web/src/features/course/pos/components/QrCodePanel.tsx
@@ -64,7 +64,8 @@ export function QrCodePanel({ shortCode }: QrCodePanelProps) {
             <div
               ref={qrRef}
               aria-label="QR code for walk-up waitlist"
-              className="bg-white p-4 rounded-md"
+              className="p-4 rounded-md"
+              style={{ backgroundColor: '#ffffff' }}
             >
               <QRCodeCanvas
                 value={shortUrl}
@@ -76,7 +77,7 @@ export function QrCodePanel({ shortCode }: QrCodePanelProps) {
 
             <div className="text-center">
               <div className="flex items-center justify-center gap-2 print:block">
-                <p className="font-mono text-sm text-muted-foreground break-all">{shortUrl}</p>
+                <p className="font-mono text-sm text-ink-muted break-all">{shortUrl}</p>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -91,10 +92,10 @@ export function QrCodePanel({ shortCode }: QrCodePanelProps) {
                   )}
                 </Button>
               </div>
-              <p className="text-xs text-muted-foreground mt-2">
+              <p className="text-xs text-ink-muted mt-2">
                 Scan to join the walk-up waitlist
               </p>
-              <p className="text-xs text-muted-foreground print:block hidden mt-1">
+              <p className="text-xs text-ink-muted print:block hidden mt-1">
                 {new Date().toLocaleDateString()}
               </p>
             </div>

--- a/src/web/src/features/course/pos/components/TeeSheetDateNav.tsx
+++ b/src/web/src/features/course/pos/components/TeeSheetDateNav.tsx
@@ -50,7 +50,7 @@ export function TeeSheetDateNav({ selectedDate, onDateChange, courseTimeZoneId }
         type="date"
         value={selectedDate}
         onChange={(e) => onDateChange(e.target.value)}
-        className="ml-1 h-8 rounded-[5px] border border-border bg-white px-2 text-[11px] text-ink"
+        className="ml-1 h-8 rounded-[5px] border border-border bg-card px-2 text-[11px] text-ink"
         aria-label="Pick date"
       />
     </div>

--- a/src/web/src/features/course/pos/components/TeeSheetGrid.tsx
+++ b/src/web/src/features/course/pos/components/TeeSheetGrid.tsx
@@ -21,7 +21,7 @@ export function TeeSheetGrid({ slots, now }: TeeSheetGridProps) {
 
   return (
     <div className="bg-paper">
-      <div className="sticky top-0 z-10 grid grid-cols-[100px_120px_1fr_80px] gap-4 border-b border-border bg-white px-6 py-2.5">
+      <div className="sticky top-0 z-10 grid grid-cols-[100px_120px_1fr_80px] gap-4 border-b border-border bg-card px-6 py-2.5">
         <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-ink-muted">Time</div>
         <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-ink-muted">Status</div>
         <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-ink-muted">Golfer</div>

--- a/src/web/src/features/course/pos/components/TeeSheetRow.tsx
+++ b/src/web/src/features/course/pos/components/TeeSheetRow.tsx
@@ -19,7 +19,7 @@ export interface TeeSheetRowProps {
 
 const VARIANT_STYLES: Record<TeeSheetRowVariant, string> = {
   past:    'bg-canvas',
-  current: 'bg-white shadow-[inset_3px_0_0_var(--green)]',
+  current: 'bg-card shadow-[inset_3px_0_0_var(--green)]',
   default: 'bg-paper',
 };
 
@@ -29,7 +29,7 @@ export function TeeSheetRow({ slot, variant }: TeeSheetRowProps) {
 
   return (
     <div
-      className={`grid min-h-[54px] grid-cols-[100px_120px_1fr_80px] items-center gap-4 border-b border-border px-6 transition-colors hover:bg-white ${VARIANT_STYLES[variant]}`}
+      className={`grid min-h-[54px] grid-cols-[100px_120px_1fr_80px] items-center gap-4 border-b border-border px-6 transition-colors hover:bg-card ${VARIANT_STYLES[variant]}`}
     >
       <div className={`font-mono text-[12px] ${isPast ? 'text-ink-muted' : 'text-ink'}`}>
         {formatWallClockTime(slot.teeTime)}

--- a/src/web/src/features/course/pos/pages/TeeSheet.tsx
+++ b/src/web/src/features/course/pos/pages/TeeSheet.tsx
@@ -46,7 +46,7 @@ export default function TeeSheet() {
           : 'Failed to load tee sheet';
         const isNotConfigured = message.toLowerCase().includes('not configured');
         return isNotConfigured ? (
-          <div className="m-6 max-w-md rounded-md border border-border bg-white p-6 text-center">
+          <div className="m-6 max-w-md rounded-md border border-border bg-card p-6 text-center">
             <p className="font-medium text-ink">Configure your tee times to get started</p>
             <p className="mt-1 text-sm text-ink-muted">
               Set your tee time interval, first tee time, and last tee time in Settings.

--- a/src/web/src/features/course/pos/pages/WalkUpWaitlist.tsx
+++ b/src/web/src/features/course/pos/pages/WalkUpWaitlist.tsx
@@ -122,7 +122,7 @@ export default function WalkUpWaitlist() {
   if (todayQuery.isError) {
     return (
       <div className="flex h-full items-center justify-center p-6">
-        <div className="w-full max-w-md rounded-xl border border-border-strong bg-white p-6 text-center">
+        <div className="w-full max-w-md rounded-xl border border-border-strong bg-card p-6 text-center">
           <p className="font-[family-name:var(--font-heading)] text-lg font-semibold text-ink">
             Couldn't load waitlist
           </p>
@@ -150,7 +150,7 @@ export default function WalkUpWaitlist() {
 
     return (
       <div className="flex h-full items-center justify-center px-4 py-6">
-        <div className="w-full max-w-md space-y-4 rounded-xl border border-border-strong bg-white p-8 text-center">
+        <div className="w-full max-w-md space-y-4 rounded-xl border border-border-strong bg-card p-8 text-center">
           <h1 className="font-[family-name:var(--font-heading)] text-xl font-semibold text-ink">
             Walk-Up Waitlist
           </h1>
@@ -250,7 +250,7 @@ export default function WalkUpWaitlist() {
             {isWide && (
               <aside
                 data-testid="queue-rail"
-                className="border-l border-border bg-white"
+                className="border-l border-border bg-card"
               >
                 {queuePanel}
               </aside>

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -72,6 +72,7 @@
     --color-red-light: var(--red-light);
     --color-blue: var(--blue);
     --color-blue-light: var(--blue-light);
+    --color-overlay: var(--overlay);
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
@@ -112,6 +113,8 @@
 
     --blue: #2563a8;
     --blue-light: #ddeaf8;
+
+    --overlay: rgba(0, 0, 0, 0.5);
 
     /* shadcn semantic mapping → Teeforce */
     --background: var(--canvas);
@@ -189,6 +192,8 @@
 
     --blue: #5a9ae0;
     --blue-light: #1a2530;
+
+    --overlay: rgba(0, 0, 0, 0.7);
 
     --background: var(--canvas);
     --foreground: var(--ink);


### PR DESCRIPTION
## Summary
- Replace 18 `bg-white` instances across layout, tee sheet, admin, and POS components with `bg-paper`/`bg-card` semantic tokens
- Add `--overlay` CSS variable and replace `bg-black/50` in all 4 overlay scrims (dialog, sheet, drawer, alert-dialog)
- Replace `text-muted-foreground` with project-preferred `text-ink-muted` in Schedule and QrCodePanel
- Replace hardcoded `amber-*` warning banner in Settings with existing `WarningAlert` component
- Fix broken `hsl()` wrapper on hex CSS variables in sidebar outline variant
- Force true white background on QR code for dark mode scannability

## Test plan
- [ ] Verify admin screens (CourseList, OrgList, UserList, DeadLetters) render correctly in dark mode
- [ ] Verify tee sheet grid, rows, and date nav have proper dark mode surfaces
- [ ] Verify WalkUpWaitlist cards and empty states use dark mode tokens
- [ ] Verify overlay scrims (dialogs, sheets, drawers) are appropriately opaque in both modes
- [ ] Verify QR code remains scannable (white background) in dark mode
- [ ] Verify Settings unsaved-changes warning renders via WarningAlert component

🤖 Generated with [Claude Code](https://claude.com/claude-code)