### PR TITLE
fix(web): wrap CoursePicker in AppShell to prevent crash

### DIFF
--- a/src/web/src/features/course/index.tsx
+++ b/src/web/src/features/course/index.tsx
@@ -4,6 +4,7 @@ import { OrgProvider } from './context/OrgContext';
 import { CourseProvider } from './context/CourseProvider';
 import { useFeature } from '@/hooks/use-features';
 import { useCourseId } from './hooks/useCourseId';
+import PickerLayout from './layouts/PickerLayout';
 import ManagementLayout from './manage/layouts/ManagementLayout';
 import PosLayout from './pos/layouts/PosLayout';
 import Dashboard from './manage/pages/Dashboard';
@@ -62,7 +63,7 @@ export default function CourseFeature() {
     <ThemeProvider>
       <OrgProvider>
         <Routes>
-          <Route index element={<CoursePicker />} />
+          <Route index element={<PickerLayout><CoursePicker /></PickerLayout>} />
           <Route path=":courseId/*" element={<CourseWithProvider />} />
         </Routes>
       </OrgProvider>

--- a/src/web/src/features/course/layouts/PickerLayout.tsx
+++ b/src/web/src/features/course/layouts/PickerLayout.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { AppShell } from '@/components/layout/AppShell';
+
+function PickerBrand() {
+  return (
+    <h1 className="text-lg font-semibold font-[family-name:var(--font-heading)] text-sidebar-foreground">
+      Teeforce
+    </h1>
+  );
+}
+
+export default function PickerLayout({ children }: { children: ReactNode }) {
+  return (
+    <AppShell variant="minimal" brand={<PickerBrand />}>
+      {children}
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary
- CoursePicker page uses `PageTopbar` which requires `AppShellContext`, but the `/course` route wasn't wrapped in `<AppShell>`, causing the app to crash immediately on load with "must be used inside `<AppShell>`"
- Wraps the CoursePicker route in `<AppShell variant="minimal">` matching the pattern used by PosLayout

## Test plan
- [ ] Visit the test site — app should load instead of showing "Something went wrong"
- [ ] Course picker page shows org/course selection with a topbar
- [ ] Navigating into a course still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)