### PR TITLE
fix(web): resolve infinite redirect loop on manage routes

### DIFF
--- a/src/web/src/components/layout/AppShell.tsx
+++ b/src/web/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from 'react';
-import { NavLink } from 'react-router';
+import { Link, NavLink } from 'react-router';
+import { Settings } from 'lucide-react';
 import {
   Sidebar,
   SidebarContent,
@@ -39,6 +40,8 @@ export interface AppShellProps {
   brand: ReactNode;
   /** Optional handler for the user menu's "Switch course" item. */
   onSwitchCourse?: () => void;
+  /** Optional settings page link — renders a gear icon in the topbar next to the user menu. */
+  settingsTo?: string;
   children: ReactNode;
 }
 
@@ -50,7 +53,7 @@ export interface AppShellProps {
  * Pages contribute topbar and right rail content via <PageTopbar> and <PageRightRail>
  * helpers from inside <Outlet>.
  */
-export function AppShell({ variant, navConfig, brand, onSwitchCourse, children }: AppShellProps) {
+export function AppShell({ variant, navConfig, brand, onSwitchCourse, settingsTo, children }: AppShellProps) {
   const [topbarLeft, setTopbarLeft] = useState<HTMLDivElement | null>(null);
   const [topbarMiddle, setTopbarMiddle] = useState<HTMLDivElement | null>(null);
   const [topbarRight, setTopbarRight] = useState<HTMLDivElement | null>(null);
@@ -65,6 +68,7 @@ export function AppShell({ variant, navConfig, brand, onSwitchCourse, children }
           <Topbar
             brand={brand}
             onSwitchCourse={onSwitchCourse}
+            settingsTo={settingsTo}
             setLeft={setTopbarLeft}
             setMiddle={setTopbarMiddle}
             setRight={setTopbarRight}
@@ -87,6 +91,7 @@ export function AppShell({ variant, navConfig, brand, onSwitchCourse, children }
           <Topbar
             brand={null}
             onSwitchCourse={onSwitchCourse}
+            settingsTo={settingsTo}
             setLeft={setTopbarLeft}
             setMiddle={setTopbarMiddle}
             setRight={setTopbarRight}
@@ -146,13 +151,14 @@ function AppSidebar({ brand, navConfig }: AppSidebarProps) {
 interface TopbarProps {
   brand: ReactNode;
   onSwitchCourse?: () => void;
+  settingsTo?: string;
   setLeft: (el: HTMLDivElement | null) => void;
   setMiddle: (el: HTMLDivElement | null) => void;
   setRight: (el: HTMLDivElement | null) => void;
   showSidebarTrigger: boolean;
 }
 
-function Topbar({ brand, onSwitchCourse, setLeft, setMiddle, setRight, showSidebarTrigger }: TopbarProps) {
+function Topbar({ brand, onSwitchCourse, settingsTo, setLeft, setMiddle, setRight, showSidebarTrigger }: TopbarProps) {
   return (
     <header className="grid h-14 shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-5 border-b border-border bg-paper px-6">
       <div className="flex items-center gap-5 justify-self-start">
@@ -163,6 +169,15 @@ function Topbar({ brand, onSwitchCourse, setLeft, setMiddle, setRight, showSideb
       <div ref={setMiddle} className="flex items-center gap-2 justify-self-center" />
       <div className="flex items-center gap-3 justify-self-end">
         <div ref={setRight} className="flex items-center gap-2 empty:hidden" />
+        {settingsTo && (
+          <Link
+            to={settingsTo}
+            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Settings"
+          >
+            <Settings className="h-5 w-5" />
+          </Link>
+        )}
         <UserMenu onSwitchCourse={onSwitchCourse} />
       </div>
     </header>

--- a/src/web/src/features/course/index.tsx
+++ b/src/web/src/features/course/index.tsx
@@ -18,15 +18,16 @@ import CoursePicker from './pages/CoursePicker';
 function CourseRoutes() {
   const courseId = useCourseId();
   const fullApp = useFeature('full-operator-app', courseId);
+  const base = `/course/${courseId}`;
 
   if (!fullApp) {
     return (
       <Routes>
         <Route path="pos" element={<PosLayout variant="minimal" />}>
           <Route path="waitlist" element={<WalkUpWaitlist />} />
-          <Route path="*" element={<Navigate to="waitlist" replace />} />
+          <Route path="*" element={<Navigate to={`${base}/pos/waitlist`} replace />} />
         </Route>
-        <Route path="*" element={<Navigate to="pos/waitlist" replace />} />
+        <Route path="*" element={<Navigate to={`${base}/pos/waitlist`} replace />} />
       </Routes>
     );
   }
@@ -42,10 +43,10 @@ function CourseRoutes() {
       <Route path="pos" element={<PosLayout />}>
         <Route path="tee-sheet" element={<TeeSheet />} />
         <Route path="waitlist" element={<WalkUpWaitlist />} />
-        <Route path="*" element={<Navigate to="tee-sheet" replace />} />
+        <Route path="*" element={<Navigate to={`${base}/pos/tee-sheet`} replace />} />
       </Route>
-      <Route index element={<Navigate to="manage" replace />} />
-      <Route path="*" element={<Navigate to="manage" replace />} />
+      <Route index element={<Navigate to={`${base}/manage`} replace />} />
+      <Route path="*" element={<Navigate to={`${base}/manage`} replace />} />
     </Routes>
   );
 }

--- a/src/web/src/features/course/manage/layouts/ManagementLayout.tsx
+++ b/src/web/src/features/course/manage/layouts/ManagementLayout.tsx
@@ -38,7 +38,7 @@ export default function ManagementLayout() {
   };
 
   return (
-    <AppShell variant="full" navConfig={navConfig} brand={<ManagementBrand />}>
+    <AppShell variant="full" navConfig={navConfig} brand={<ManagementBrand />} settingsTo={`/course/${courseId}/manage/settings`}>
       <Outlet />
     </AppShell>
   );

--- a/src/web/src/features/course/pos/layouts/PosLayout.tsx
+++ b/src/web/src/features/course/pos/layouts/PosLayout.tsx
@@ -45,6 +45,7 @@ export default function PosLayout({ variant = 'full' }: PosLayoutProps) {
       variant={variant}
       navConfig={variant === 'full' ? navConfig : undefined}
       brand={<PosBrand />}
+      settingsTo={`/course/${courseId}/manage/settings`}
     >
       <Outlet />
     </AppShell>


### PR DESCRIPTION
## Summary
- Fixed infinite redirect loop when navigating to `/course/:courseId/manage` — relative `<Navigate>` paths in catch-all routes caused endless URL segment appending (`/manage/manage/manage...`)
- Switched all course route redirects to absolute paths using `/course/${courseId}/...`
- Added a settings gear icon to the topbar (next to user avatar) in both POS and Management layouts, linking to manage/settings

## Test plan
- [x] `pnpm --dir src/web lint` — clean (only pre-existing warning)
- [x] `pnpm --dir src/web test` — all 141 tests pass
- [ ] Navigate to `/course/:courseId/manage` — should load Dashboard without looping
- [ ] Navigate to `/course/:courseId/pos/tee-sheet` — should load Tee Sheet without looping
- [ ] Verify gear icon appears in topbar next to user avatar on both POS and Manage layouts
- [ ] Verify gear icon links to `/course/:courseId/manage/settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)