### PR TITLE
fix(web): org name visibility in light-mode POS topbar and stray gear icon

### DIFF
--- a/src/web/src/features/course/manage/layouts/ManagementLayout.tsx
+++ b/src/web/src/features/course/manage/layouts/ManagementLayout.tsx
@@ -9,7 +9,7 @@ function ManagementBrand() {
   return (
     <>
       <h1
-        className="max-w-[180px] truncate text-lg font-semibold font-[family-name:var(--font-heading)] text-sidebar-foreground"
+        className="max-w-[180px] truncate text-lg font-semibold font-[family-name:var(--font-heading)]"
         title={user?.organization?.name ?? 'Teeforce'}
       >
         {user?.organization?.name ?? 'Teeforce'}

--- a/src/web/src/features/course/pos/layouts/PosLayout.tsx
+++ b/src/web/src/features/course/pos/layouts/PosLayout.tsx
@@ -9,7 +9,7 @@ function PosBrand() {
   return (
     <>
       <h1
-        className="max-w-[180px] truncate text-lg font-semibold font-[family-name:var(--font-heading)] text-sidebar-foreground"
+        className="max-w-[180px] truncate text-lg font-semibold font-[family-name:var(--font-heading)]"
         title={user?.organization?.name ?? 'Teeforce'}
       >
         {user?.organization?.name ?? 'Teeforce'}
@@ -45,7 +45,7 @@ export default function PosLayout({ variant = 'full' }: PosLayoutProps) {
       variant={variant}
       navConfig={variant === 'full' ? navConfig : undefined}
       brand={<PosBrand />}
-      settingsTo={`/course/${courseId}/manage/settings`}
+      settingsTo={variant === 'full' ? `/course/${courseId}/manage/settings` : undefined}
     >
       <Outlet />
     </AppShell>


### PR DESCRIPTION
## Summary
- Drop explicit `text-sidebar-foreground` on the POS and Management brand `h1`. The shadcn `Sidebar` root applies that color to its children, so inheritance gives us the right color in both contexts — dark sidebar in the full variant and ink-on-paper in the minimal POS topbar (previously invisible in light mode).
- Only pass `settingsTo` from `PosLayout` when `variant === 'full'`. The minimal variant runs when `full-operator-app` is off, so manage routes redirect back to the waitlist — the gear looked broken.

## Test plan
- [x] Light-mode minimal POS topbar shows "Benjamin Golf Co" in dark ink (verified via DOM inspection + screenshot)
- [x] Minimal POS no longer renders a settings gear
- [x] Management sidebar brand still renders on dark green with readable white text
- [x] Management topbar gear icon present and navigates to `/course/:id/manage/settings`
- [x] `pnpm --dir src/web lint`
- [x] `pnpm --dir src/web test` (141 tests passing)