### PR TITLE
fix(web): show error state when weekly schedule API fails

### DIFF
--- a/src/web/src/features/course/__tests__/Schedule.test.tsx
+++ b/src/web/src/features/course/__tests__/Schedule.test.tsx
@@ -115,6 +115,18 @@ describe('Schedule', () => {
     );
   });
 
+  it('shows error message when API fails', () => {
+    mockUseWeeklySchedule.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useWeeklySchedule>);
+
+    render(<Schedule />);
+
+    expect(screen.getByText('Unable to load schedule. Please try again later.')).toBeInTheDocument();
+  });
+
   it('shows not-configured message when settings are missing', () => {
     mockUseTeeTimeSettings.mockReturnValue({
       data: undefined,

--- a/src/web/src/features/course/manage/pages/Dashboard.tsx
+++ b/src/web/src/features/course/manage/pages/Dashboard.tsx
@@ -92,7 +92,9 @@ export default function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {statusCounts ? (
+            {weeklyQuery.isError ? (
+              <p className="text-sm text-ink-muted">Unable to load</p>
+            ) : statusCounts ? (
               <p className="text-sm text-ink">
                 {statusCounts.published} published, {statusCounts.draft} draft,{' '}
                 {statusCounts.notStarted} not started

--- a/src/web/src/features/course/manage/pages/Schedule.tsx
+++ b/src/web/src/features/course/manage/pages/Schedule.tsx
@@ -52,7 +52,7 @@ export default function Schedule() {
   const [selectedDates, setSelectedDates] = useState<Set<string>>(new Set());
 
   const startDateStr = formatDateParam(weekStart);
-  const { data, isLoading } = useWeeklySchedule(courseId, startDateStr);
+  const { data, isLoading, isError } = useWeeklySchedule(courseId, startDateStr);
   const bulkDraft = useBulkDraft();
   const { data: settings } = useTeeTimeSettings(courseId);
 
@@ -161,6 +161,10 @@ export default function Schedule() {
             {Array.from({ length: 7 }).map((_, i) => (
               <Skeleton key={i} className="h-28 rounded-lg" />
             ))}
+          </div>
+        ) : isError ? (
+          <div className="text-center py-12 text-ink-muted">
+            <p>Unable to load schedule. Please try again later.</p>
           </div>
         ) : (
           <div className="grid grid-cols-7 gap-3">


### PR DESCRIPTION
## Summary

- Destructure `isError` from `useWeeklySchedule` in `Schedule.tsx` and render a centered `text-ink-muted` message instead of a blank grid when the API fails
- Add `isError` branch in `Dashboard.tsx` "This Week" card so it shows "Unable to load" instead of perpetual "Loading..." on API failure

## Test plan

- [ ] Simulate a network error or 404 on `GET /tee-sheets/week` — Schedule page should show "Unable to load schedule. Please try again later." instead of a blank grid
- [ ] Same failure condition on Dashboard — "This Week" card should show "Unable to load" instead of "Loading..."
- [ ] Happy path: normal API response still renders the day grid and status counts correctly
- [ ] Loading state still renders the skeleton grid while the request is in flight

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)