### PR TITLE
fix(web): prevent feature flag race condition on hard navigation

### DIFF
--- a/src/web/src/features/course/__tests__/index.test.tsx
+++ b/src/web/src/features/course/__tests__/index.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { type ReactNode } from 'react';
+import CourseFeature from '../index';
+import { useFeatures } from '@/hooks/use-features';
+
+// Mock all heavy layouts and pages so we can test routing without full render trees
+vi.mock('../layouts/PickerLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../manage/layouts/ManagementLayout', () => ({
+  default: () => <div data-testid="management-layout">Management</div>,
+}));
+vi.mock('../pos/layouts/PosLayout', () => ({
+  default: () => <div data-testid="pos-layout">POS</div>,
+}));
+vi.mock('../pages/CoursePicker', () => ({
+  default: () => <div data-testid="course-picker">Picker</div>,
+}));
+vi.mock('../context/CourseProvider', () => ({
+  CourseProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../context/OrgContext', () => ({
+  OrgProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/ThemeProvider', () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/SplashScreen', () => ({
+  default: () => <div data-testid="splash-screen">Loading</div>,
+}));
+vi.mock('@/hooks/use-features');
+
+const mockUseFeatures = vi.mocked(useFeatures);
+
+function renderAtPath(path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/course/*" element={<CourseFeature />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CourseFeature routing', () => {
+  it('renders SplashScreen while feature flags are loading', () => {
+    mockUseFeatures.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useFeatures>);
+
+    renderAtPath('/course/course-123/manage');
+
+    expect(screen.getByTestId('splash-screen')).toBeInTheDocument();
+    expect(screen.queryByTestId('management-layout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pos-layout')).not.toBeInTheDocument();
+  });
+
+  it('renders management layout when full-operator-app flag is true', () => {
+    mockUseFeatures.mockReturnValue({
+      data: { 'full-operator-app': true },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFeatures>);
+
+    renderAtPath('/course/course-123/manage');
+
+    expect(screen.getByTestId('management-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('splash-screen')).not.toBeInTheDocument();
+  });
+
+  it('renders POS layout when full-operator-app flag is false', () => {
+    mockUseFeatures.mockReturnValue({
+      data: { 'full-operator-app': false },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFeatures>);
+
+    renderAtPath('/course/course-123/pos/waitlist');
+
+    expect(screen.getByTestId('pos-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('management-layout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('splash-screen')).not.toBeInTheDocument();
+  });
+
+  it('does not render management routes when full-operator-app flag is false', () => {
+    mockUseFeatures.mockReturnValue({
+      data: { 'full-operator-app': false },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFeatures>);
+
+    renderAtPath('/course/course-123/manage');
+
+    expect(screen.queryByTestId('management-layout')).not.toBeInTheDocument();
+  });
+});

--- a/src/web/src/features/course/index.tsx
+++ b/src/web/src/features/course/index.tsx
@@ -2,8 +2,9 @@ import { Routes, Route, Navigate } from 'react-router';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { OrgProvider } from './context/OrgContext';
 import { CourseProvider } from './context/CourseProvider';
-import { useFeature } from '@/hooks/use-features';
+import { useFeatures } from '@/hooks/use-features';
 import { useCourseId } from './hooks/useCourseId';
+import SplashScreen from '@/components/SplashScreen';
 import PickerLayout from './layouts/PickerLayout';
 import ManagementLayout from './manage/layouts/ManagementLayout';
 import PosLayout from './pos/layouts/PosLayout';
@@ -17,8 +18,13 @@ import CoursePicker from './pages/CoursePicker';
 
 function CourseRoutes() {
   const courseId = useCourseId();
-  const fullApp = useFeature('full-operator-app', courseId);
+  const { data, isLoading } = useFeatures(courseId);
+  const fullApp = data?.['full-operator-app'] ?? false;
   const base = `/course/${courseId}`;
+
+  if (isLoading) {
+    return <SplashScreen />;
+  }
 
   if (!fullApp) {
     return (


### PR DESCRIPTION
## Summary

- `CourseRoutes` was calling `useFeature()` which defaults to `false` while the query is loading, causing an immediate redirect to `/pos/waitlist` on hard navigation
- Switched to `useFeatures()` directly to access `isLoading`, and render `<SplashScreen />` while the feature flags query is in-flight
- Once data resolves, `fullApp` is derived correctly and the right route set renders

## Test plan

- [ ] Hard-navigate (paste URL or refresh) to `/course/:courseId/manage` — should see SplashScreen briefly, then render the management layout
- [ ] Hard-navigate to `/course/:courseId/pos/tee-sheet` — same, no redirect to waitlist
- [ ] Client-side navigation continues to work normally
- [ ] Course with `full-operator-app: false` still correctly restricts to `/pos/waitlist`
- [ ] All 141 existing frontend tests pass

Closes #429

Generated with [Claude Code](https://claude.com/claude-code)