### PR TITLE
fix: WeeklyStatusEndpoint returns 404 due to DateOnly query param binding

### DIFF
--- a/src/backend/Teeforce.Api/Features/TeeSheet/Endpoints/WeeklyStatusEndpoint.cs
+++ b/src/backend/Teeforce.Api/Features/TeeSheet/Endpoints/WeeklyStatusEndpoint.cs
@@ -27,16 +27,20 @@ public static class WeeklyStatusEndpoint
     [Authorize(Policy = AuthorizationPolicies.RequireAppAccess)]
     public static async Task<IResult> Handle(
         Guid courseId,
-        DateOnly? startDate,
+        string? startDate,
         ApplicationDbContext db,
         CancellationToken ct)
     {
-        if (startDate is null)
+        if (string.IsNullOrWhiteSpace(startDate))
         {
             return Results.BadRequest(new { error = "startDate query parameter is required." });
         }
 
-        var start = startDate.Value;
+        if (!DateOnly.TryParseExact(startDate, "yyyy-MM-dd", out var start))
+        {
+            return Results.BadRequest(new { error = "startDate must be in yyyy-MM-dd format." });
+        }
+
         var end = start.AddDays(6);
 
         var sheets = await db.TeeSheets


### PR DESCRIPTION
## Summary

- Wolverine HTTP cannot bind `DateOnly?` from query strings — the endpoint was receiving `null` for `startDate` even when the parameter was present, causing the endpoint to never match and return 404
- Changed `DateOnly? startDate` to `string? startDate` with manual `DateOnly.TryParseExact("yyyy-MM-dd")` parsing, matching the identical pattern in `TeeSheetEndpoints.GetTeeSheet` and `PublishTeeSheetEndpoint.Handle`
- Also adds an explicit 400 response for invalid date format (e.g. `?startDate=not-a-date`), which the integration tests in `WeeklyTeeSheetSetupTests` already cover

## Test plan

- [x] `WeeklyStatusRequestValidatorTests` — existing unit tests pass (no changes to validator)
- [x] `WeeklyTeeSheetSetupTests` integration tests cover Step1 (returns 200 with data), Step6 (missing param → 400), and Step7 (invalid date → 400)

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)