### PR TITLE
fix(web): clear unsaved changes banner after successful settings save

### DIFF
--- a/src/web/src/features/course/manage/pages/Settings.tsx
+++ b/src/web/src/features/course/manage/pages/Settings.tsx
@@ -77,7 +77,11 @@ export default function Settings() {
   }, [settingsQuery.data, form]);
 
   function onSubmit(data: TeeTimeSettingsFormData) {
-    updateMutation.mutate({ courseId, data });
+    updateMutation.mutate({ courseId, data }, {
+      onSuccess: () => {
+        form.reset(data);
+      },
+    });
   }
 
   return (


### PR DESCRIPTION
## Summary

- After a successful PUT to save tee time settings, `form.reset(data)` is now called in the mutation's `onSuccess` callback
- This resets React Hook Form's `isDirty` flag to `false`, which hides the "You have unsaved changes" banner
- Previously the banner persisted indefinitely after saving because `isDirty` was never cleared

## Test plan

- [ ] Navigate to the tee time settings page
- [ ] Change any field value — "You have unsaved changes" banner appears
- [ ] Click "Save Settings"
- [ ] Banner disappears after the save succeeds
- [ ] Navigating away after save does not trigger the "unsaved changes" blocker dialog

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)