### PR TITLE
fix(web): restore Dev SMS nav link in admin sidebar

### DIFF
--- a/src/backend/Teeforce.Api/Program.cs
+++ b/src/backend/Teeforce.Api/Program.cs
@@ -124,18 +124,8 @@ if (builder.Environment.IsProduction())
     builder.Services.Configure<TelnyxOptions>(builder.Configuration.GetSection("Telnyx"));
     builder.Services.AddTransient<TelnyxAuthHandler>(); // Must be transient — HttpClient factory requirement
     builder.Services
-        .AddHttpClient<TelnyxSmsSender>(client => client.BaseAddress = new Uri("https://api.telnyx.com"))
+        .AddHttpClient<ISmsSender, TelnyxSmsSender>(client => client.BaseAddress = new Uri("https://api.telnyx.com"))
         .AddHttpMessageHandler<TelnyxAuthHandler>();
-    builder.Services.AddScoped<ISmsSender, TelnyxSmsSender>();
-
-    // DatabaseSmsSender is needed in non-Production environments because the /dev/sms/inbound
-    // endpoint (mapped below for all non-Production envs) depends on it directly. Without this
-    // registration, ASP.NET parameter inference fails at startup and kills the entire app —
-    // preventing all Wolverine endpoints from registering.
-    if (!builder.Environment.IsProduction())
-    {
-        builder.Services.AddScoped<DatabaseSmsSender>();
-    }
 }
 else
 {

--- a/src/backend/Teeforce.Api/Program.cs
+++ b/src/backend/Teeforce.Api/Program.cs
@@ -140,7 +140,7 @@ if (builder.Environment.IsProduction())
 else
 {
     builder.Services.AddScoped<DatabaseSmsSender>();
-    builder.Services.AddScoped<ISmsSender>(sp => sp.GetRequiredService<DatabaseSmsSender>());
+    builder.Services.AddScoped<ISmsSender, DatabaseSmsSender>();
 }
 builder.Services.AddSingleton<IFeatureService, FeatureService>();
 builder.Services.AddScoped<ICourseRepository, CourseRepository>();

--- a/src/backend/Teeforce.Api/Program.cs
+++ b/src/backend/Teeforce.Api/Program.cs
@@ -118,13 +118,8 @@ builder.Services.AddScoped<ISmsFormatter<WaitlistOfferAvailable>, WaitlistOfferA
 builder.Services.AddScoped<ISmsFormatter<WaitlistOfferExpired>, WaitlistOfferExpiredSmsFormatter>();
 builder.Services.AddScoped<ISmsFormatter<WalkupConfirmation>, WalkupConfirmationSmsFormatter>();
 
-// SMS channel — environment-dependent
-if (builder.Environment.IsDevelopment())
-{
-    builder.Services.AddScoped<DatabaseSmsSender>();
-    builder.Services.AddScoped<ISmsSender>(sp => sp.GetRequiredService<DatabaseSmsSender>());
-}
-else
+// SMS channel — Telnyx in Production, database capture everywhere else
+if (builder.Environment.IsProduction())
 {
     builder.Services.Configure<TelnyxOptions>(builder.Configuration.GetSection("Telnyx"));
     builder.Services.AddTransient<TelnyxAuthHandler>(); // Must be transient — HttpClient factory requirement
@@ -141,6 +136,11 @@ else
     {
         builder.Services.AddScoped<DatabaseSmsSender>();
     }
+}
+else
+{
+    builder.Services.AddScoped<DatabaseSmsSender>();
+    builder.Services.AddScoped<ISmsSender>(sp => sp.GetRequiredService<DatabaseSmsSender>());
 }
 builder.Services.AddSingleton<IFeatureService, FeatureService>();
 builder.Services.AddScoped<ICourseRepository, CourseRepository>();

--- a/src/web/src/features/admin/navigation.tsx
+++ b/src/web/src/features/admin/navigation.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react';
 import type { NavConfig } from '@/components/layout/AppShell';
 
+const isDevMode = import.meta.env.DEV || import.meta.env.VITE_SHOW_DEV_TOOLS === 'true';
+
 export const adminNav: NavConfig = {
   sections: [
     {
@@ -19,6 +21,14 @@ export const adminNav: NavConfig = {
         { to: '/admin/dead-letters', label: 'Dead Letters' },
       ],
     },
+    ...(isDevMode
+      ? [
+          {
+            label: 'Dev Tools',
+            items: [{ to: '/admin/dev/sms', label: 'SMS Viewer' }],
+          },
+        ]
+      : []),
   ],
 };
 


### PR DESCRIPTION
Adds a "Dev Tools" section to adminNav with an "SMS Viewer" link to /admin/dev/sms, gated behind the same dev-mode check used by the route definition.