### PR TITLE
fix: golfer pages crash and schedule week Unpublish button

### DIFF
--- a/src/web/src/components/layout/GolferLayout.tsx
+++ b/src/web/src/components/layout/GolferLayout.tsx
@@ -1,5 +1,4 @@
 import { NavLink, Outlet } from 'react-router';
-import UserMenu from '@/components/layout/UserMenu';
 
 export default function GolferLayout() {
   return (
@@ -8,7 +7,6 @@ export default function GolferLayout() {
       <header className="border-b bg-white px-4 py-3">
         <div className="flex items-center justify-between">
           <h1 className="text-lg font-bold">Teeforce</h1>
-          <UserMenu />
         </div>
       </header>
 

--- a/src/web/src/features/course/__tests__/Schedule.test.tsx
+++ b/src/web/src/features/course/__tests__/Schedule.test.tsx
@@ -5,6 +5,7 @@ import { useWeeklySchedule } from '../manage/hooks/useWeeklySchedule';
 import { useBulkDraft } from '../manage/hooks/useBulkDraft';
 import { useTeeTimeSettings } from '../manage/hooks/useTeeTimeSettings';
 import { usePublishTeeSheet } from '../manage/hooks/usePublishTeeSheet';
+import { useUnpublishTeeSheet } from '../manage/hooks/useUnpublishTeeSheet';
 
 vi.mock('../hooks/useCourseId', () => ({
   useCourseId: () => 'course-1',
@@ -13,11 +14,13 @@ vi.mock('../manage/hooks/useWeeklySchedule');
 vi.mock('../manage/hooks/useBulkDraft');
 vi.mock('../manage/hooks/useTeeTimeSettings');
 vi.mock('../manage/hooks/usePublishTeeSheet');
+vi.mock('../manage/hooks/useUnpublishTeeSheet');
 
 const mockUseWeeklySchedule = vi.mocked(useWeeklySchedule);
 const mockUseBulkDraft = vi.mocked(useBulkDraft);
 const mockUseTeeTimeSettings = vi.mocked(useTeeTimeSettings);
 const mockUsePublishTeeSheet = vi.mocked(usePublishTeeSheet);
+const mockUseUnpublishTeeSheet = vi.mocked(useUnpublishTeeSheet);
 
 const weekData = {
   weekStart: '2026-04-13',
@@ -35,6 +38,7 @@ const weekData = {
 
 const mockDraftMutate = vi.fn();
 const mockPublishMutate = vi.fn();
+const mockUnpublishMutate = vi.fn();
 
 function defaultMocks() {
   mockUseWeeklySchedule.mockReturnValue({
@@ -55,6 +59,11 @@ function defaultMocks() {
     mutate: mockPublishMutate,
     isPending: false,
   } as unknown as ReturnType<typeof usePublishTeeSheet>);
+
+  mockUseUnpublishTeeSheet.mockReturnValue({
+    mutate: mockUnpublishMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useUnpublishTeeSheet>);
 }
 
 beforeEach(() => {
@@ -150,7 +159,7 @@ describe('Schedule', () => {
   it('shows Publish button on Draft cards but not on other statuses', () => {
     render(<Schedule />);
 
-    const publishButtons = screen.getAllByRole('button', { name: /Publish/i });
+    const publishButtons = screen.getAllByRole('button', { name: 'Publish' });
     // Only 1 Draft card in weekData (Apr 14)
     expect(publishButtons).toHaveLength(1);
   });
@@ -158,11 +167,31 @@ describe('Schedule', () => {
   it('calls publish mutation when Publish button is clicked', () => {
     render(<Schedule />);
 
-    const publishButton = screen.getByRole('button', { name: /Publish/i });
+    const publishButton = screen.getByRole('button', { name: 'Publish' });
     fireEvent.click(publishButton);
 
     expect(mockPublishMutate).toHaveBeenCalledWith(
       { courseId: 'course-1', date: '2026-04-14' },
+      expect.any(Object),
+    );
+  });
+
+  it('shows Unpublish button on Published cards', () => {
+    render(<Schedule />);
+
+    const unpublishButtons = screen.getAllByRole('button', { name: 'Unpublish' });
+    // Only 1 Published card in weekData (Apr 15)
+    expect(unpublishButtons).toHaveLength(1);
+  });
+
+  it('calls unpublish mutation when Unpublish button is clicked', () => {
+    render(<Schedule />);
+
+    const unpublishButton = screen.getByRole('button', { name: 'Unpublish' });
+    fireEvent.click(unpublishButton);
+
+    expect(mockUnpublishMutate).toHaveBeenCalledWith(
+      { courseId: 'course-1', date: '2026-04-15' },
       expect.any(Object),
     );
   });

--- a/src/web/src/features/course/manage/pages/Schedule.tsx
+++ b/src/web/src/features/course/manage/pages/Schedule.tsx
@@ -12,6 +12,7 @@ import { useWeeklySchedule } from '../hooks/useWeeklySchedule';
 import { useBulkDraft } from '../hooks/useBulkDraft';
 import { useTeeTimeSettings } from '../hooks/useTeeTimeSettings';
 import { usePublishTeeSheet } from '../hooks/usePublishTeeSheet';
+import { useUnpublishTeeSheet } from '../hooks/useUnpublishTeeSheet';
 import type { DayStatus } from '@/types/tee-time';
 
 const statusConfig = {
@@ -56,6 +57,7 @@ export default function Schedule() {
   const { data, isLoading, isError } = useWeeklySchedule(courseId, startDateStr);
   const bulkDraft = useBulkDraft();
   const publishTeeSheet = usePublishTeeSheet();
+  const unpublishTeeSheet = useUnpublishTeeSheet();
   const { data: settings } = useTeeTimeSettings(courseId);
 
   const isConfigured = !!settings?.firstTeeTime;
@@ -179,6 +181,8 @@ export default function Schedule() {
                 onToggle={() => toggleDate(day.date)}
                 onPublish={(date) => publishTeeSheet.mutate({ courseId, date }, {})}
                 isPublishing={publishTeeSheet.isPending}
+                onUnpublish={(date) => unpublishTeeSheet.mutate({ courseId, date }, {})}
+                isUnpublishing={unpublishTeeSheet.isPending}
               />
             ))}
           </div>
@@ -195,12 +199,15 @@ interface DayCardProps {
   onToggle: () => void;
   onPublish: (date: string) => void;
   isPublishing: boolean;
+  onUnpublish: (date: string) => void;
+  isUnpublishing: boolean;
 }
 
-function DayCard({ day, courseId, isSelected, onToggle, onPublish, isPublishing }: DayCardProps) {
+function DayCard({ day, courseId, isSelected, onToggle, onPublish, isPublishing, onUnpublish, isUnpublishing }: DayCardProps) {
   const config = statusConfig[day.status];
   const isNotStarted = day.status === 'notStarted';
   const isDraft = day.status === 'draft';
+  const isPublished = day.status === 'published';
 
   const cardContent = (
     <Card className={isSelected ? 'ring-2 ring-primary' : ''}>
@@ -230,6 +237,20 @@ function DayCard({ day, courseId, isSelected, onToggle, onPublish, isPublishing 
             }}
           >
             Publish
+          </Button>
+        )}
+        {isPublished && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full"
+            disabled={isUnpublishing}
+            onClick={(e) => {
+              e.preventDefault();
+              onUnpublish(day.date);
+            }}
+          >
+            Unpublish
           </Button>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- **#444 — Golfer pages crash on load**: Removed `UserMenu` from `GolferLayout`. Golfer routes are public (no `AuthProvider`), so `useAuth()` threw an unhandled error on `/golfer` and `/golfer/tee-times`.
- **#445 — Missing Unpublish button**: Added an Unpublish button to Published cards in the weekly schedule overview, using the existing `useUnpublishTeeSheet` hook, consistent with the Draft → Publish button pattern.

Part of #399

Closes #444
Closes #445

## Test plan
- [x] Frontend tests pass (163/163), including 2 new tests for Unpublish button
- [x] Frontend lint passes
- [x] Backend builds successfully
- [ ] Verify `/golfer/tee-times` loads without crash
- [ ] Verify Published cards in Schedule week view show Unpublish button
- [ ] Verify clicking Unpublish reverts tee sheet to Draft status

🤖 Generated with [Claude Code](https://claude.com/claude-code)